### PR TITLE
[XENOPS-1123] remove share-file-store cleanup interval from configmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1533,7 +1533,7 @@ Default: http://solr-service:30300/solr/alfresco/replication?command=backup&repo
 #### `transformServices.transformCoreAio.livenessProbe.enabled`
 
 * Required: false
-* Default: false
+* Default: true
 * Description: will enable liveness and readiness probes  
 additional settings can be added through additionalEnvironmentVariables.  
 ```yaml

--- a/README.md
+++ b/README.md
@@ -1388,8 +1388,8 @@ Default: http://solr-service:30300/solr/alfresco/replication?command=backup&repo
 * Default: None
 * Example:
   ```yaml
-  environmentVariable1Key: environmentVariable1Value
-  environmentVariable2Key: environmentVariable2Value
+  scheduler.cleanup.interval: "10800000"
+  scheduler.content.age.millis: "43200000"
   ```
 * Description: With this list of parameters you can add 1 or multiple environment variables that will be passed to the
   docker container. These will be stored in a config and are hence not safe for sensitive information
@@ -1510,8 +1510,9 @@ Default: http://solr-service:30300/solr/alfresco/replication?command=backup&repo
 * Default: None
 * Example:
   ```yaml
-  environmentVariable1Key: environmentVariable1Value
-  environmentVariable2Key: environmentVariable2Value
+    livenessPercent: "150"
+    livenessTransformPeriodSeconds: "600"
+    maxTransforms: "100000"
   ```
 * Description: With this list of parameters you can add 1 or multiple environment variables that will be passed to the
   docker container. These will be stored in a config and are hence not safe for sensitive information
@@ -1529,6 +1530,18 @@ Default: http://solr-service:30300/solr/alfresco/replication?command=backup&repo
   - secretRef:
     name: s3-secret
 ```
+#### `transformServices.transformCoreAio.livenessProbe.enabled`
+
+* Required: false
+* Default: false
+* Description: will enable liveness and readiness probes  
+additional settings can be added through additionalEnvironmentVariables.  
+```yaml
+  livenessPercent: "150"
+  livenessTransformPeriodSeconds: "600"
+  maxTransforms: "100000"
+  ```
+
 
 #### `transformServices.transformCoreAio.podAnnotations`
 
@@ -1536,8 +1549,8 @@ Default: http://solr-service:30300/solr/alfresco/replication?command=backup&repo
 * Default: None
 * Example:
   ```yaml
-  annotation1Key: annotation1Value
-  annotation2Key: annotation2Value
+     prometheus.io/path: actuator/prometheus
+     prometheus.io/scrape: 'true'
   ```
 * Description: With this list of parameters you can add 1 or multiple annotations to the Transform Core All In One
 

--- a/xenit-alfresco/templates/transform-services/shared-file-store/shared-file-store-config.yaml
+++ b/xenit-alfresco/templates/transform-services/shared-file-store/shared-file-store-config.yaml
@@ -9,8 +9,6 @@ metadata:
 data:
   livenessPercent: "150"
   livenessSavePeriodSeconds: "600"
-  scheduler.cleanup.interval: "86400000"
-  scheduler.content.age.millis: "86400000"
   {{- if .Values.transformServices.sharedFileStore.additionalEnvironmentVariables }}
   {{ toYaml .Values.transformServices.sharedFileStore.additionalEnvironmentVariables | nindent 2 }}
   {{- end }}

--- a/xenit-alfresco/templates/transform-services/transform-core-aio/transform-core-aio-deployment.yaml
+++ b/xenit-alfresco/templates/transform-services/transform-core-aio/transform-core-aio-deployment.yaml
@@ -55,6 +55,23 @@ spec:
             {{ toYaml .Values.transformServices.transformCoreAio.resources.limits | nindent 14 }}
             {{- end }}
           {{- end }}
+          {{- if .Values.transformServices.transformCoreAio.livenessProbe.enabled -}}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8090
+            initialDelaySeconds: 20
+            periodSeconds: 60
+            timeoutSeconds: 10
+            livenessProbe:
+              httpGet:
+                path: /live
+                port: 8090
+              initialDelaySeconds: 10
+              periodSeconds: 30
+              failureThreshold: 1
+              timeoutSeconds: 10
+          {{- end }}
       imagePullSecrets:
         {{- if .Values.general.imagePullSecrets}}
         {{ toYaml .Values.general.imagePullSecrets | nindent 8 }}

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -182,8 +182,10 @@ transformServices:
       type: RollingUpdate
     resources:
       requests:
-        memory: "256Mi"
+        memory: "1600Mi"
         cpu: "150m"
+    livenessProbe:
+      enabled: false
   transformRouter:
     replicas: 1
     image:

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -185,7 +185,7 @@ transformServices:
         memory: "1600Mi"
         cpu: "150m"
     livenessProbe:
-      enabled: false
+      enabled: true
   transformRouter:
     replicas: 1
     image:


### PR DESCRIPTION
remove default settings for shared-file-store for cleanup from configmap so they can be personalized for individual deployments.
+ add liveness and readiness probe settings for transformcoreAio
+ changed default memory req for transformCoreAio