### PR TITLE
[XENOPS-1123] fix syntax error in deploy file

### DIFF
--- a/xenit-alfresco/templates/transform-services/transform-core-aio/transform-core-aio-deployment.yaml
+++ b/xenit-alfresco/templates/transform-services/transform-core-aio/transform-core-aio-deployment.yaml
@@ -55,7 +55,7 @@ spec:
             {{ toYaml .Values.transformServices.transformCoreAio.resources.limits | nindent 14 }}
             {{- end }}
           {{- end }}
-          {{- if .Values.transformServices.transformCoreAio.livenessProbe.enabled -}}
+          {{- if .Values.transformServices.transformCoreAio.livenessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /ready


### PR DESCRIPTION
syntax error in deploy file prohibited helm from creating manifest.