### PR TITLE
[OUPSLA-2] mitigate liveness probe transform-core-aio issue

### DIFF
--- a/xenit-alfresco/templates/transform-services/transform-core-aio/transform-core-aio-deployment.yaml
+++ b/xenit-alfresco/templates/transform-services/transform-core-aio/transform-core-aio-deployment.yaml
@@ -65,7 +65,7 @@ spec:
             timeoutSeconds: 10
           livenessProbe:
             httpGet:
-              path: /live
+              path: /ready
               port: 8090
             initialDelaySeconds: 10
             periodSeconds: 30


### PR DESCRIPTION
latest version of transform-core-aio liveness probe does not fail after maxtransforms is reached while readiness probe does fail making the service unavailable instead of having the pod restarted.
Interim fix is to use readiness endpoint also for liveness checks untill problem is solved at Alfresco.