### PR TITLE
[EUIAUDIT23-7] correct cilium ooi connections to sharepoint online

### DIFF
--- a/xenit-alfresco/templates/ooi/cilium-network-policy.yml
+++ b/xenit-alfresco/templates/ooi/cilium-network-policy.yml
@@ -12,5 +12,8 @@ spec:
   egress:
     - toFQDNs:
         - matchName: "graph.microsoft.com"
+        - matchPattern: "*.*.*.*.sharepoint.com"
+        - matchPattern: "*.*.*.sharepoint.com"
+        - matchPattern: "*.*.sharepoint.com"
         - matchPattern: "*.sharepoint.com"
 {{- end }}


### PR DESCRIPTION
Sharepoint online uses `<hostname>.gr.global.aa-rt.sharepoint.com` uri which is not mapped by the standard `*.sharepoint.com` pattern. 