### PR TITLE
[BNPPFSLA-1005]: added configuration to disable default ingress rules…

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,10 +570,10 @@ For more information take a look at
           name: ldap3-ad-auth-config
         name: ldap3-ad-auth-volume
 ```
-#### `acs.ingress.rule.enabled`
+#### `acs.ingress.enabled`
 * Required: false
 * Default: `true`
-* Description: this will enable/disable the ingress http rule for the acs-service. By default this rule will forward calls to /alfresco to acs-service:30000
+* Description: this will enable/disable the ingress for the acs-service. By default this rule will forward calls to /alfresco to acs-service:30000
 
 ### Digital Workspace
 
@@ -708,10 +708,10 @@ For more information take a look at
   ```
 * Description: If you use an image that is not public. then you can create dockerconfigjson secrets on your cluster and
   reference them here.
-#### `digitalWorkspace.ingress.rule.enabled`
+#### `digitalWorkspace.ingress.enabled`
 * Required: false
 * Default: `true`
-* Description: this will enable/disable the ingress http rule for the digitalWorkspaceService. By default this rule will forward calls to .Values.digitalWorkspace.basePath to digital-workspace-service:30200
+* Description: this will enable/disable the ingress for the digitalWorkspaceService. By default this rule will forward calls to .Values.digitalWorkspace.basePath to digital-workspace-service:30200
 ### Share
 
 #### `share.enabled`
@@ -908,10 +908,10 @@ For more information take a look at
   ```
 * Description: If you use an image that is not public. then you can create dockerconfigjson secrets on your cluster and
   reference them here.
-#### `share.ingress.rule.enabled`
+#### `share.ingress.enabled`
 * Required: false
 * Default: `true`
-* Description: this will enable/disable the ingress http rule for alfresco share. By default this rule will forward calls to /share to share-service:30100
+* Description: this will enable/disable the ingress for alfresco share. By default this rule will forward calls to /share to share-service:30100
 ### Active MQ
 
 #### `mq.adminLogin`
@@ -2058,10 +2058,10 @@ additional settings can be added through additionalEnvironmentVariables.
 * Description: If you use an image that is not public. then you can create dockerconfigjson secrets on your cluster and
   reference them here.
 
-#### `ooi.ingress.rule.enabled`
+#### `ooi.ingress.enabled`
 * Required: false
 * Default: `true`
-* Description: this will enable/disable the ingress http rule for the ooi-service. By default this rule will forward calls to /ooi-service to ooi-service:30500
+* Description: this will enable/disable the ingress for the ooi-service. By default this rule will forward calls to /ooi-service to ooi-service:30500
 
 
 ### Persistent Storage

--- a/README.md
+++ b/README.md
@@ -570,7 +570,10 @@ For more information take a look at
           name: ldap3-ad-auth-config
         name: ldap3-ad-auth-volume
 ```
-
+#### `acs.ingress.rule.enabled`
+* Required: false
+* Default: `true`
+* Description: this will enable/disable the ingress http rule for the acs-service. By default this rule will forward calls to /alfresco to acs-service:30000
 
 ### Digital Workspace
 
@@ -705,7 +708,10 @@ For more information take a look at
   ```
 * Description: If you use an image that is not public. then you can create dockerconfigjson secrets on your cluster and
   reference them here.
-
+#### `digitalWorkspace.ingress.rule.enabled`
+* Required: false
+* Default: `true`
+* Description: this will enable/disable the ingress http rule for the digitalWorkspaceService. By default this rule will forward calls to .Values.digitalWorkspace.basePath to digital-workspace-service:30200
 ### Share
 
 #### `share.enabled`
@@ -902,7 +908,10 @@ For more information take a look at
   ```
 * Description: If you use an image that is not public. then you can create dockerconfigjson secrets on your cluster and
   reference them here.
-
+#### `share.ingress.rule.enabled`
+* Required: false
+* Default: `true`
+* Description: this will enable/disable the ingress http rule for alfresco share. By default this rule will forward calls to /share to share-service:30100
 ### Active MQ
 
 #### `mq.adminLogin`
@@ -2048,6 +2057,12 @@ additional settings can be added through additionalEnvironmentVariables.
   ```
 * Description: If you use an image that is not public. then you can create dockerconfigjson secrets on your cluster and
   reference them here.
+
+#### `ooi.ingress.rule.enabled`
+* Required: false
+* Default: `true`
+* Description: this will enable/disable the ingress http rule for the ooi-service. By default this rule will forward calls to /ooi-service to ooi-service:30500
+
 
 ### Persistent Storage
 

--- a/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
+++ b/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
@@ -29,7 +29,7 @@ spec:
   - host: {{ required "A host where your alfresco services can be reached on must be specified in values.ingress.host" .Values.ingress.host }}
     http:
       paths:
-      {{- if .Values.acs.ingress.rule.enabled }}
+      {{- if .Values.acs.ingress.enabled }}
       - path: /alfresco
         pathType: Prefix
         backend:
@@ -38,7 +38,7 @@ spec:
             port:
               number: 30000
       {{- end }}
-      {{- if and .Values.share.enabled .Values.share.ingress.rule.enabled }}
+      {{- if and .Values.share.enabled .Values.share.ingress.enabled }}
       - path: /share
         pathType: Prefix
         backend:
@@ -47,7 +47,7 @@ spec:
             port:
               number: 30100
       {{- end }}
-      {{- if and .Values.digitalWorkspace.enabled .Values.digitalWorkspace.ingress.rule.enabled }}
+      {{- if and .Values.digitalWorkspace.enabled .Values.digitalWorkspace.ingress.enabled }}
       - path: {{ .Values.digitalWorkspace.basePath }}
         pathType: Prefix
         backend:
@@ -56,7 +56,7 @@ spec:
             port:
               number: 30200
       {{- end }}
-      {{- if and .Values.ooi.enabled .Values.ooi.ingress.rule.enabled }}
+      {{- if and .Values.ooi.enabled .Values.ooi.ingress.enabled }}
       - path: /ooi-service
         pathType: Prefix
         backend:

--- a/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
+++ b/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
@@ -29,6 +29,7 @@ spec:
   - host: {{ required "A host where your alfresco services can be reached on must be specified in values.ingress.host" .Values.ingress.host }}
     http:
       paths:
+      {{- if .Values.acs.ingress.rule.enabled }}
       - path: /alfresco
         pathType: Prefix
         backend:
@@ -36,7 +37,8 @@ spec:
             name: acs-service
             port:
               number: 30000
-      {{- if .Values.share.enabled }}
+      {{- end }}
+      {{- if and .Values.share.enabled .Values.share.ingress.rule.enabled }}
       - path: /share
         pathType: Prefix
         backend:
@@ -45,7 +47,7 @@ spec:
             port:
               number: 30100
       {{- end }}
-      {{- if .Values.digitalWorkspace.enabled }}
+      {{- if and .Values.digitalWorkspace.enabled .Values.digitalWorkspace.ingress.rule.enabled }}
       - path: {{ .Values.digitalWorkspace.basePath }}
         pathType: Prefix
         backend:
@@ -54,7 +56,7 @@ spec:
             port:
               number: 30200
       {{- end }}
-      {{- if .Values.ooi.enabled }}
+      {{- if and .Values.ooi.enabled .Values.ooi.ingress.rule.enabled }}
       - path: /ooi-service
         pathType: Prefix
         backend:

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -80,8 +80,7 @@ acs:
     successThreshold: 1
     timeoutSeconds: 10
   ingress:
-    rule:
-      enabled: true
+    enabled: true
 digitalWorkspace:
   enabled: true
   replicas: 1
@@ -97,8 +96,7 @@ digitalWorkspace:
       cpu: "150m"
   basePath: "/workspace"
   ingress:
-    rule:
-      enabled: true
+    enabled: true
 share:
   enabled: true
   mergeAcsShare: false
@@ -126,8 +124,7 @@ share:
     successThreshold: 1
     timeoutSeconds: 10
   ingress:
-    rule:
-      enabled: true
+    enabled: true
 
 mq:
   enabled: true
@@ -253,8 +250,7 @@ ooi:
       memory: "128Mi"
       cpu: "100m"
   ingress:
-    rule:
-      enabled: true
+    enabled: true
 
 persistentStorage:
   alfresco:

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -79,6 +79,9 @@ acs:
     periodSeconds: 20
     successThreshold: 1
     timeoutSeconds: 10
+  ingress:
+    rule:
+      enabled: true
 digitalWorkspace:
   enabled: true
   replicas: 1
@@ -93,7 +96,9 @@ digitalWorkspace:
       memory: "256Mi"
       cpu: "150m"
   basePath: "/workspace"
-
+  ingress:
+    rule:
+      enabled: true
 share:
   enabled: true
   mergeAcsShare: false
@@ -120,6 +125,9 @@ share:
     periodSeconds: 20
     successThreshold: 1
     timeoutSeconds: 10
+  ingress:
+    rule:
+      enabled: true
 
 mq:
   enabled: true
@@ -244,6 +252,9 @@ ooi:
     requests:
       memory: "128Mi"
       cpu: "100m"
+  ingress:
+    rule:
+      enabled: true
 
 persistentStorage:
   alfresco:


### PR DESCRIPTION
PR to be able to individually disable ingress rules.

Generate default chart template:
`helm template --namespace alfresco-helm-template helm-alfresco ./xenit-alfresco/ --values ./xenit-alfresco/values.yaml --set ingress.host=testhost`

Isolate ingress resource:
helm template -s didn't work so:
`grep -i alfresco-ingress.yaml -A 100`

switching new values on/off.
`helm template --namespace alfresco-helm-template helm-alfresco ./xenit-alfresco/ --values ./xenit-alfresco/values.yaml --set ingress.host=testhost --set share.ingress.rule.enabled=false   | grep -i alfresco-ingress.yaml -A 100`

Switch off all ingress rules except solr block rules:
`helm template --namespace alfresco-helm-template helm-alfresco ./xenit-alfresco/ --values ./xenit-alfresco/values.yaml --set ingress.host=testhost --set acs.ingress.rule.enabled=false --set share.ingress.rule.enabled=false --set ooi.ingress.rule.enabled=false --set digitalWorkspace.ingress.rule.enabled=false | grep -i alfresco-ingress.yaml -A 100`

Also switch off solr block rules:
`helm template --namespace alfresco-helm-template helm-alfresco ./xenit-alfresco/ --values ./xenit-alfresco/values.yaml --set ingress.host=testhost --set acs.ingress.rule.enabled=false --set share.ingress.rule.enabled=false --set ooi.ingress.rule.enabled=false --set digitalWorkspace.ingress.rule.enabled=false --set ingress.blockAcsSolrApi.enabled=false | grep -i alfresco-ingress.yaml -A 100`

This will generate an empy paths array, needs to be tested if k8s deployments stumble over this.


`
  defaultBackend:
    service:
      name: acs-service
      port:
        number: 30000
  rules:
  - host: testhost
    http:
      paths:
---
`