### PR TITLE
updated set of restricted urls

### DIFF
--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -31,7 +31,7 @@ ingress:
     paths:
       - /alfresco/s/api/solr
       - /alfresco/service/api/solr
-      - /alfresco/service/api/solr
+      - /alfresco/wcs/api/solr
       - /alfresco/wcservice/api/solr
 acs:
   replicas: 1


### PR DESCRIPTION
Added blocked URL.

Please have a look at this repo, there are 2 more URLS referenced, but I do not think they are relevant?
https://github.com/aborroy/search-services-replication?tab=readme-ov-file#solr-considerations

before/after test can be done in browser:
<hostname>/alfresco/wcs/api/solr/nextTransaction?fromCommitTime=0