### PR TITLE
[Xenops 1164] remove defaultbackend and replace with nginx-default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ chronology things are added/fixed/changed and - where possible - links to the PR
 ### Changes
 [XENOPS-1164]  date: 10 May 2024
 * remove defaultBackend from ingress rules, this should not be set by individual namespace resources
+* defaultBackend will point to new nginx-default-service providing 404 if page not found.
 * defaultBackend will be mapped to default ingress root path for the alfresco host only
-* possibility to set ingress root path to nginx-403.
+
 
 
 [XENOPS-1161] 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 chronology things are added/fixed/changed and - where possible - links to the PRs involved.
 
 ### Changes
+[XENOPS-1164]  date: 10 May 2024
+* remove defaultBackend from ingress rules, this should not be set by individual namespace resources
+* defaultBackend will be mapped to default ingress root path for the alfresco host only
+* possibility to set ingress root path to nginx-403.
+
+
 [XENOPS-1161] 
 * change liveness probe threshold to trigger after readiness probe failure to avoid looping restarts on slow systems 
  

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ For more information take a look at
 
 * Required: false
 * Default: None
+* Remark: Do not use this to set the root`/` path, that should be set by either the defaultBackend or `ingress.blockAcsSolrApi.redirectRootToCustomNginx` 
 * Example:
 
 ```yaml
@@ -276,6 +277,8 @@ For more information take a look at
 * Required: true
 * Default: acs-service
 * Description: the default service name that ingress will point to
+> [!IMPORTANT]  
+> This will no longer set the actual ingress default Backend, instead it will set the service responsible for serving the root`/` path
 
 #### `ingress.defaultBackend.port`
 
@@ -288,6 +291,14 @@ For more information take a look at
 * Required: false
 * Default: `true`
 * Description: Enable 403 handler for alfresco api solr endpoints
+
+#### `ingress.blockAcsSolrApi.redirectRootToCustomNginx`
+* Required: false
+* Default: `false`
+* Description: Set 404 handler as root path for this ingress host.   
+ If set to `false` the root path will be redirected to the defaultBackend.service.  
+ Take care NOT to overwrite this using an `ingress.additionalPaths` setting! 
+  
 #### `ingress.blockAcsSolrApi.paths`
 
 * Required: false

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ For more information take a look at
 
 * Required: false
 * Default: None
-* Remark: Do not use this to set the root`/` path, that should be set by either the defaultBackend or `ingress.blockAcsSolrApi.redirectRootToCustomNginx` 
+* Remark: Do not use this to set the root`/` path, that should be set by the defaultBackend
 * Example:
 
 ```yaml
@@ -275,10 +275,8 @@ For more information take a look at
 #### `ingress.defaultBackend.service`
 
 * Required: true
-* Default: acs-service
+* Default: nginx-default-service
 * Description: the default service name that ingress will point to
-> [!IMPORTANT]  
-> This will no longer set the actual ingress default Backend, instead it will set the service responsible for serving the root`/` path
 
 #### `ingress.defaultBackend.port`
 
@@ -292,12 +290,6 @@ For more information take a look at
 * Default: `true`
 * Description: Enable 403 handler for alfresco api solr endpoints
 
-#### `ingress.blockAcsSolrApi.redirectRootToCustomNginx`
-* Required: false
-* Default: `false`
-* Description: Set 404 handler as root path for this ingress host.   
- If set to `false` the root path will be redirected to the defaultBackend.service.  
- Take care NOT to overwrite this using an `ingress.additionalPaths` setting! 
   
 #### `ingress.blockAcsSolrApi.paths`
 

--- a/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
+++ b/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
@@ -20,11 +20,6 @@ spec:
       # Provide a unique secret to store the SSL credentials
       secretName: tls-alfresco-{{ .Release.Name }}-secret
   {{- end }}
-  #defaultBackend:
-  #  service:
-  #    name: {{ .Values.ingress.defaultBackend.service }}
-  #    port:
-  #      number: {{ .Values.ingress.defaultBackend.port }}
   rules:
   - host: {{ required "A host where your alfresco services can be reached on must be specified in values.ingress.host" .Values.ingress.host }}
     http:

--- a/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
+++ b/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
@@ -29,15 +29,7 @@ spec:
   - host: {{ required "A host where your alfresco services can be reached on must be specified in values.ingress.host" .Values.ingress.host }}
     http:
       paths:
-      {{- if ingress.blockAcsSolrApi.enabled and ingress.blockAcsSolrApi.redirectRootToCustomNginx }}
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: nginx-403-service
-            port:
-              number: 30403
-      {{- else }}
+      {{- if .Values.ingress.defaultBackend }}
       - path: /
         pathType: Prefix
         backend:
@@ -88,7 +80,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: nginx-403-service
+            name: nginx-default-service
             port:
               number: 30403
       {{- end }}

--- a/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
+++ b/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
@@ -20,15 +20,32 @@ spec:
       # Provide a unique secret to store the SSL credentials
       secretName: tls-alfresco-{{ .Release.Name }}-secret
   {{- end }}
-  defaultBackend:
-    service:
-      name: {{ .Values.ingress.defaultBackend.service }}
-      port:
-        number: {{ .Values.ingress.defaultBackend.port }}
+  #defaultBackend:
+  #  service:
+  #    name: {{ .Values.ingress.defaultBackend.service }}
+  #    port:
+  #      number: {{ .Values.ingress.defaultBackend.port }}
   rules:
   - host: {{ required "A host where your alfresco services can be reached on must be specified in values.ingress.host" .Values.ingress.host }}
     http:
       paths:
+      {{- if ingress.blockAcsSolrApi.enabled and ingress.blockAcsSolrApi.redirectRootToCustomNginx }}
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: nginx-403-service
+            port:
+              number: 30403
+      {{- else }}
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Values.ingress.defaultBackend.service }}
+            port:
+              number: {{ .Values.ingress.defaultBackend.port }}
+      {{- end }}
       {{- if .Values.acs.ingress.enabled }}
       - path: /alfresco
         pathType: Prefix

--- a/xenit-alfresco/templates/ingress/nginx-403-config.yaml
+++ b/xenit-alfresco/templates/ingress/nginx-403-config.yaml
@@ -14,12 +14,20 @@ data:
       worker_connections  1024;
     }
     http{
+      log_format xenit_json escape=json '{ "time":"$time_iso8601","timestamp":$msec,"responseStatus":$status,"type":"access","requestTime":"$request_time","requestMethod":"$request_method","remoteAddr":"$remote_addr","requestUri":"$request" }';
+      access_log /var/log/nginx/access.log xenit_json;
       server {
         listen 80;
         server_name _;
-    
-        location / {
+        {{- if .Values.ingress.blockAcsSolrApi.enabled -}}
+        {{- range $.Values.ingress.blockAcsSolrApi.paths }}
+        location {{ . }} {
           return 403 'Forbidden';
+        }
+        {{- end }}
+        {{- end }} 
+        location / {
+          return 404 'Sorry, this page is not served here.';
         }
       }
     }

--- a/xenit-alfresco/templates/ingress/nginx-default-config.yaml
+++ b/xenit-alfresco/templates/ingress/nginx-default-config.yaml
@@ -1,11 +1,10 @@
-{{- if .Values.ingress.blockAcsSolrApi.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-403-configmap
+  name: nginx-default-configmap
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app: nginx-403
+    app: nginx-default
 data:
   nginx.conf: |
     worker_processes  1;
@@ -31,4 +30,4 @@ data:
         }
       }
     }
-{{- end }}
+

--- a/xenit-alfresco/templates/ingress/nginx-default-deployment.yaml
+++ b/xenit-alfresco/templates/ingress/nginx-default-deployment.yaml
@@ -1,20 +1,19 @@
-{{- if .Values.ingress.blockAcsSolrApi.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-403
+  name: nginx-default
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app: nginx-403
+    app: nginx-default
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nginx-403
+      app: nginx-default
   template:
     metadata:
       labels:
-        app: nginx-403
+        app: nginx-default
     spec:
       containers:
         - name: nginx
@@ -28,5 +27,4 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            name: nginx-403-configmap
-{{- end }}
+            name: nginx-default-configmap

--- a/xenit-alfresco/templates/ingress/nginx-default-service.yaml
+++ b/xenit-alfresco/templates/ingress/nginx-default-service.yaml
@@ -1,17 +1,15 @@
-{{- if .Values.ingress.blockAcsSolrApi.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: nginx-403-service
+  name: nginx-default-service
   namespace: {{ .Release.Namespace | quote }}
 spec:
   {{- if .Values.general.serviceType }}
   type: {{ .Values.general.serviceType }}
   {{- end }}
   selector:
-    app: nginx-403
+    app: nginx-default
   ports:
     - port: 30403
       targetPort: 80
       protocol: TCP
-{{- end }}

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -24,11 +24,10 @@ ingress:
     kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-production"
   defaultBackend:
-    service: acs-service
-    port: 30000
+    service: nginx-default-service
+    port: 30403
   blockAcsSolrApi:
     enabled: true
-    redirectRootToCustomNginx: false
     paths:
       - /alfresco/s/api/solr
       - /alfresco/service/api/solr

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -28,6 +28,7 @@ ingress:
     port: 30000
   blockAcsSolrApi:
     enabled: true
+    redirectRootToCustomNginx: false
     paths:
       - /alfresco/s/api/solr
       - /alfresco/service/api/solr


### PR DESCRIPTION
Individual deployments should not set the cluster defaultBackend as this could lead to invalid redirects.
* defaultBackend is now mapped to the root / path instead.
* nginx-403 has been replaced with nginx-default and will also serve as 404
* access logging has been added to nginx-default