### PR TITLE
KANSUP74-23: introduce additional pvcs activemq

### DIFF
--- a/README.md
+++ b/README.md
@@ -1076,6 +1076,26 @@ Digital Workspace are disabled.
 * Description: If you use an image that is not public. then you can create dockerconfigjson secrets on your cluster and
   reference them here.
 
+#### `mq.additionalVolumes`
+* Required: false
+* Default: None
+* Description: A list of additional volumes for the mq pods. Example:
+```yaml
+      - name: activemq-data-1
+        persistentVolumeClaim:
+          claimName: alfresco-pvc-1
+```
+
+#### `mq.additionalVolumeMounts`
+* Required: false
+* Default: None
+* Description: A list of additional volume mounts for the mq pods. Example:
+```yaml
+      - name: activemq-data-1
+        mountPath: /mountpath
+        subPath: subpath
+```
+
 ### Postgresql
 
 #### `postgresql.enabled`
@@ -2270,3 +2290,18 @@ additional settings can be added through additionalEnvironmentVariables.
 * Required: when `persistentStorage.mq.storageClassName` is `scw-bssd`
 * Default: None
 * Description: The volume handle pointing to the AWS EFS location
+
+### `persistentStorage.mq.additionalClaims`
+* Required: false
+* Default: None
+* Description: A list of additional volume claims that can be added to the mq pods. Layout should be as follows:
+
+```yaml
+      - name: name1
+        mountPath: /apps/example
+        subPath: subPath/example
+        storageClassName: "standard"
+        storage: 2
+        efs:
+          volumeHandle: "efs-identifier"
+```

--- a/xenit-alfresco/templates/active-mq/mq-deployment.yaml
+++ b/xenit-alfresco/templates/active-mq/mq-deployment.yaml
@@ -78,8 +78,8 @@ spec:
             {{ toYaml .Values.mq.resources.limits | nindent 14 }}
             {{- end }}
           {{- end }}
-          {{- if .Values.persistentStorage.mq.enabled }}
           volumeMounts:
+          {{- if .Values.persistentStorage.mq.enabled }}
             - name: data
               mountPath: /opt/activemq/data
               subPath: mq/data
@@ -119,8 +119,8 @@ spec:
         {{- if .Values.mq.imagePullSecrets}}
         {{ toYaml .Values.mq.imagePullSecrets | nindent 8 }}
         {{- end }}
-      {{- if .Values.persistentStorage.mq.enabled }}
       volumes:
+      {{- if .Values.persistentStorage.mq.enabled }}
         - name: data
           persistentVolumeClaim:
             claimName: mq-pvc

--- a/xenit-alfresco/templates/active-mq/mq-deployment.yaml
+++ b/xenit-alfresco/templates/active-mq/mq-deployment.yaml
@@ -84,6 +84,16 @@ spec:
               mountPath: /opt/activemq/data
               subPath: mq/data
           {{- end }}
+          {{- if .Values.persistentStorage.mq.additionalClaims }}
+          {{- range .Values.persistentStorage.mq.additionalClaims }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.mq.additionalVolumeMounts }}
+          {{- toYaml .Values.mq.additionalVolumeMounts | nindent 12 }}
+          {{- end }}
       {{- if .Values.persistentStorage.mq.initVolumes }}
       initContainers:
         - name: init-fs
@@ -115,4 +125,14 @@ spec:
           persistentVolumeClaim:
             claimName: mq-pvc
       {{- end }}
+        {{- if .Values.persistentStorage.mq.additionalClaims }}
+      {{- range .Values.persistentStorage.mq.additionalClaims }}
+        - name: {{ .name }}
+          persistentVolumeClaim:
+            claimName: {{ .name }}-pvc
+      {{- end }}
+        {{- end }}
+        {{- if .Values.mq.additionalVolumes }}
+        {{- toYaml .Values.mq.additionalVolumes | nindent 8 }}
+        {{- end }}
 {{- end }}

--- a/xenit-alfresco/templates/storage/mq-volumes.yaml
+++ b/xenit-alfresco/templates/storage/mq-volumes.yaml
@@ -8,5 +8,15 @@
 {{- $efsVolumeHandle := .efs.volumeHandle -}}
 {{- include "hepers.volumeHelper" (list $namespace $name $storageClassName $storage $efsVolumeHandle) }}
 {{- end }}
+{{- if .additionalClaims }}
+{{- range .additionalClaims }}
+{{- $name := .name -}}
+{{- $storageClassName := .storageClassName -}}
+{{- $storage := .storage -}}
+{{- $efsVolumeHandle := .efs.volumeHandle -}}
+{{- include "hepers.volumeHelper" (list $namespace $name $storageClassName $storage $efsVolumeHandle) }}
+---
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Started from https://xenitsupport.jira.com/browse/KANSUP74-23

Kansspelcommissie uses an NFS mount for both the ACS, Solr & ActiveMQ data.
For ACS, the problem was previously addressed by disabling the persistent storage of the ACS pods & adding a replacement volume & mount for a PV(C) pointing to the NFS mount. However, this option does not seem to be possible for ActiveMQ with the current version of our Helm charts.

This PR:
- introduces the mq.additionalVolumes option;
- introduces the mq.additionalVolumeMounts option;
- introduces the persistentStorage.mq.additionalClaims option.

An alternative solution would have been to introduce NFS support in the volume helper. However, most templates for Kansspelcommissie have already been written, so investing time in this alternative approach seems to be wasteful at the moment. 