### PR TITLE
[Xenops 1200] add hibernation mode to scale down replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 chronology things are added/fixed/changed and - where possible - links to the PRs involved.
 
 ### Changes
+[v0.7.5]
+* added general.hibernate to set all replicas to 0
+
 [v0.7.4]
 * added mq.additionalVolumes
 * added mq.additionalVolumeMounts

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ For more information take a look at
 Transform Service Shared File Storage, Clustering (replica count should always have a max of 1 for ACS pods), MQ and 
 Digital Workspace are disabled. 
 
+#### `general.hibernate`
+
+* Required: false
+* Default: false
+* Description: Setting this parameter to true will set all replicas to 0 and alter the default
+nginx rules to redirect the normal pages to a 503 maintenance page.
+
+
 
 #### `general.strategy`
 

--- a/xenit-alfresco/Chart.yaml
+++ b/xenit-alfresco/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.7.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/xenit-alfresco/templates/acs/acs-deployment.yaml
+++ b/xenit-alfresco/templates/acs/acs-deployment.yaml
@@ -7,7 +7,9 @@ metadata:
   labels:
     app: acs
 spec:
-  {{- if  .Values.general.enterprise }}
+  {{- if .Values.general.hibernate }}
+  replicas: 0
+  {{- else if  .Values.general.enterprise }}
   replicas: {{ .Values.acs.replicas }}
   {{- else }}
   replicas: 1

--- a/xenit-alfresco/templates/active-mq/mq-deployment.yaml
+++ b/xenit-alfresco/templates/active-mq/mq-deployment.yaml
@@ -7,7 +7,11 @@ metadata:
   labels:
     app: mq
 spec:
+  {{- if .Values.general.hibernate }}
+  replicas: 0
+  {{- else }}
   replicas: {{ .Values.mq.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       app: mq

--- a/xenit-alfresco/templates/digital-workspace/digital-workspace-deployment.yaml
+++ b/xenit-alfresco/templates/digital-workspace/digital-workspace-deployment.yaml
@@ -7,7 +7,11 @@ metadata:
   labels:
     app: digital-workspace
 spec:
+  {{- if .Values.general.hibernate }}
+  replicas: 0
+  {{- else }}
   replicas: {{ .Values.digitalWorkspace.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       app: digital-workspace

--- a/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
+++ b/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
@@ -31,7 +31,15 @@ spec:
   - host: {{ required "A host where your alfresco services can be reached on must be specified in values.ingress.host" .Values.ingress.host }}
     http:
       paths:
-      {{- if .Values.ingress.defaultPath }}
+      {{- if .Values.general.hibernate }}
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: nginx-default-service
+            port:
+              number: 30403
+      {{- else if .Values.ingress.defaultPath }}
       - path: /
         pathType: Prefix
         backend:
@@ -40,7 +48,7 @@ spec:
             port:
               number: {{ .Values.ingress.defaultPath.port }}
       {{- end }}
-      {{- if .Values.acs.ingress.enabled }}
+      {{- if and .Values.acs.ingress.enabled (not .Values.general.hibernate) }}
       - path: /alfresco
         pathType: Prefix
         backend:
@@ -49,7 +57,7 @@ spec:
             port:
               number: 30000
       {{- end }}
-      {{- if and .Values.share.enabled .Values.share.ingress.enabled }}
+      {{- if and .Values.share.enabled .Values.share.ingress.enabled (not .Values.general.hibernate) }}
       - path: /share
         pathType: Prefix
         backend:
@@ -58,7 +66,7 @@ spec:
             port:
               number: 30100
       {{- end }}
-      {{- if and .Values.digitalWorkspace.enabled .Values.digitalWorkspace.ingress.enabled }}
+      {{- if and .Values.digitalWorkspace.enabled .Values.digitalWorkspace.ingress.enabled (not .Values.general.hibernate) }}
       - path: {{ .Values.digitalWorkspace.basePath }}
         pathType: Prefix
         backend:
@@ -67,7 +75,7 @@ spec:
             port:
               number: 30200
       {{- end }}
-      {{- if and .Values.ooi.enabled .Values.ooi.ingress.enabled }}
+      {{- if and .Values.ooi.enabled .Values.ooi.ingress.enabled (not .Values.general.hibernate) }}
       - path: /ooi-service
         pathType: Prefix
         backend:
@@ -87,10 +95,10 @@ spec:
               number: 30403
       {{- end }}
       {{- end }}
-      {{- if .Values.ingress.additionalPaths }}
+      {{- if and .Values.ingress.additionalPaths (not .Values.general.hibernate) }}
       {{ toYaml .Values.ingress.additionalPaths | nindent 6 }}
       {{- end }}
-  {{- if .Values.syncService.enabled }}
+  {{- if and .Values.syncService.enabled (not .Values.general.hibernate) }}
   - host: {{ required "If sync Services are enabled a specific host for sync services must be specified in values.ingress.syncServiceHost" .Values.ingress.syncServiceHost }}
     http:
       paths:

--- a/xenit-alfresco/templates/ingress/nginx-default-config.yaml
+++ b/xenit-alfresco/templates/ingress/nginx-default-config.yaml
@@ -29,7 +29,30 @@ data:
           return 403 'Forbidden';
         }
         {{- end }}
-        {{- end }} 
+        {{- end }}
+        {{- if .Values.general.hibernate }}
+        location /alfresco {
+          return 302 /maintenance;
+        }
+        {{- if and .Values.share.enabled .Values.share.ingress.enabled }}
+        location /share {
+          return 302 /maintenance;
+        }
+        {{- end }}
+        {{- if and .Values.digitalWorkspace.enabled .Values.digitalWorkspace.ingress.enabled }}
+        location {{ .Values.digitalWorkspace.basePath }} {
+          return 302 /maintenance;
+        }
+        {{- end }}
+        {{- if and .Values.ooi.enabled .Values.ooi.ingress.enabled }}
+        location /ooi-service {
+          return 302 /maintenance;
+        }
+        {{- end }}
+        location /maintenance {
+          return 503 'Sorry, this application is currently hibernated.';
+        }
+        {{- end }}
         location / {
           return 404 'Sorry, this page is not served here.';
         }

--- a/xenit-alfresco/templates/ingress/nginx-default-deployment.yaml
+++ b/xenit-alfresco/templates/ingress/nginx-default-deployment.yaml
@@ -12,6 +12,10 @@ spec:
       app: nginx-default
   template:
     metadata:
+      annotations:
+      {{- if .Values.general.hibernate }}
+        hibernated: 'true'
+      {{- end }}
       labels:
         app: nginx-default
     spec:

--- a/xenit-alfresco/templates/ooi/ooi-deployment.yaml
+++ b/xenit-alfresco/templates/ooi/ooi-deployment.yaml
@@ -12,7 +12,11 @@ metadata:
   labels:
     app: ooi
 spec:
+  {{- if .Values.general.hibernate }}
+  replicas: 0
+  {{- else }}
   replicas: {{ .Values.ooi.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       app: ooi

--- a/xenit-alfresco/templates/postgres/postgresql-deployment.yaml
+++ b/xenit-alfresco/templates/postgres/postgresql-deployment.yaml
@@ -7,7 +7,11 @@ metadata:
   labels:
     app: postgresql
 spec:
+  {{- if .Values.general.hibernate }}
+  replicas: 0
+  {{- else }}
   replicas: 1
+  {{- end }}
   selector:
     matchLabels:
       app: postgresql

--- a/xenit-alfresco/templates/share/share-deployment.yaml
+++ b/xenit-alfresco/templates/share/share-deployment.yaml
@@ -7,7 +7,11 @@ metadata:
   labels:
     app: share
 spec:
+  {{- if .Values.general.hibernate }}
+  replicas: 0
+  {{- else }}
   replicas: {{ .Values.share.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       app: share

--- a/xenit-alfresco/templates/solr/solr-backup/solr-backup-cron.yml
+++ b/xenit-alfresco/templates/solr/solr-backup/solr-backup-cron.yml
@@ -1,4 +1,4 @@
-{{- if and (.Values.solr.enabled) (.Values.solr.autoBackup.enabled) -}}
+{{- if and (.Values.solr.enabled) (.Values.solr.autoBackup.enabled) (not .Values.general.hibernate) -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/xenit-alfresco/templates/solr/solr-stateful-set.yaml
+++ b/xenit-alfresco/templates/solr/solr-stateful-set.yaml
@@ -7,7 +7,11 @@ metadata:
   labels:
     app: solr
 spec:
+  {{- if .Values.general.hibernate }}
+  replicas: 0
+  {{- else }}
   replicas: {{ .Values.solr.replicas }}
+  {{- end }}
   podManagementPolicy: {{ .Values.solr.podManagementPolicy }}
   selector:
     matchLabels:

--- a/xenit-alfresco/templates/sync-service/sync-service-deployment.yaml
+++ b/xenit-alfresco/templates/sync-service/sync-service-deployment.yaml
@@ -7,7 +7,11 @@ metadata:
   labels:
     app: sync-service
 spec:
+  {{- if .Values.general.hibernate }}
+  replicas: 0
+  {{- else }}
   replicas: {{ .Values.syncService.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       app: sync-service

--- a/xenit-alfresco/templates/transform-services/shared-file-store/shared-file-store-deployment.yaml
+++ b/xenit-alfresco/templates/transform-services/shared-file-store/shared-file-store-deployment.yaml
@@ -7,7 +7,11 @@ metadata:
   labels:
     app: shared-file-store
 spec:
+  {{- if .Values.general.hibernate }}
+  replicas: 0
+  {{- else }}
   replicas: {{ .Values.transformServices.sharedFileStore.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       app: shared-file-store

--- a/xenit-alfresco/templates/transform-services/transform-core-aio/transform-core-aio-deployment.yaml
+++ b/xenit-alfresco/templates/transform-services/transform-core-aio/transform-core-aio-deployment.yaml
@@ -7,7 +7,11 @@ metadata:
   labels:
     app: transform-core-aio
 spec:
+  {{- if .Values.general.hibernate }}
+  replicas: 0
+  {{- else }}
   replicas: {{ .Values.transformServices.transformCoreAio.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       app: transform-core-aio

--- a/xenit-alfresco/templates/transform-services/transform-router/transform-router-deployment.yaml
+++ b/xenit-alfresco/templates/transform-services/transform-router/transform-router-deployment.yaml
@@ -7,7 +7,11 @@ metadata:
   labels:
     app: transform-router
 spec:
+  {{- if .Values.general.hibernate }}
+  replicas: 0
+  {{- else }}
   replicas: {{ .Values.transformServices.transformRouter.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       app: transform-router

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -1,4 +1,5 @@
 general:
+  hibernate: false
   enterprise: true
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
Provides a helm value "hibernate" which will scale down all replicas to 0 and redirect ingress to a maintenance message.