### PR TITLE
NYS2AWS-43 refine controls on netpols & cilium netpols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ chronology things are added/fixed/changed and - where possible - links to the PR
 
 [v0.8.0]
 
+* refined network policies creation
 * **Potentially breaking change**: changed `alfresco-ingress` definition & default values to enable usage of `ingressClassName` property in favour of `kubernetes.io/ingress.class` annotation.
 
   **⚠️ This may particularly impact aws deployments using alb**

--- a/README.md
+++ b/README.md
@@ -189,13 +189,22 @@ nginx rules to redirect the normal pages to a 503 maintenance page.
 * Default: true
 * Description: A field to enabled/disable network policies.
 
+#### `general.networkPolicies.cilium.enabled`
+
+* Required: false
+* Default: true
+* Description: A field to enable/disable ciliumnetworkpolicies.
+
 #### `general.cni`
 
 * Required: false
 * Default: cilium
 * Description: A field to tell the helm chart what cni provider your cluster is using. By default we assume cilium. If
   this is not the case you will need to add a network policy to allow the following
-* Alfresco to access heartbeat
+  * Alfresco to access heartbeat
+* **Note**: setting the cni to cilium, no longer automatically enables cilium policies:
+  * Cilium can enforce just regular k8s network policies, ciliumnetworkpolicies are not implied by usage of cilium.
+  * It is possible to run cilium chained to another cni (which we currently do on AWS).
 
 #### `general.secrets.acs.selfManaged`
 

--- a/integration-testing/src/test/java/eu/xenit/testing/k8s/kind/HelmAlfrescoTest.java
+++ b/integration-testing/src/test/java/eu/xenit/testing/k8s/kind/HelmAlfrescoTest.java
@@ -32,6 +32,9 @@ class HelmAlfrescoTest {
         var values = """
                 general:
                   cni: kindnetd
+                  networkPolicies:
+                    cilium:
+                      enabled: false
                 ingress:
                   host: test
                   protocol: http

--- a/local-values.yaml
+++ b/local-values.yaml
@@ -26,3 +26,5 @@ digitalWorkspace:
 general:
   networkPolicies:
     enabled: false
+    cilium:
+      enabled: false

--- a/xenit-alfresco/Chart.yaml
+++ b/xenit-alfresco/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.5
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/xenit-alfresco/templates/acs/cilium-network-policy.yml
+++ b/xenit-alfresco/templates/acs/cilium-network-policy.yml
@@ -1,4 +1,4 @@
-{{- if and (.Values.general.networkPolicies.enabled) (eq .Values.general.cni "cilium") }}
+{{- if and (.Values.general.networkPolicies.enabled) (.Values.general.networkPolicies.cilium.enabled) }}
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:

--- a/xenit-alfresco/templates/acs/network-policy.yml
+++ b/xenit-alfresco/templates/acs/network-policy.yml
@@ -1,4 +1,5 @@
 {{- if .Values.general.networkPolicies.enabled }}
+{{- if .Values.postgresql.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -19,6 +20,8 @@ spec:
       ports:
         - protocol: TCP
           port: 5432
+{{- end }}
+{{- if .Values.mq.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -39,6 +42,8 @@ spec:
       ports:
         - protocol: TCP
           port: 61616
+{{- end }}
+{{- if .Values.transformServices.transformCoreAio.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -59,6 +64,7 @@ spec:
       ports:
         - protocol: TCP
           port: 8090
+{{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -86,66 +92,6 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: acs-to-sync-service
-spec:
-  podSelector:
-    matchLabels:
-      app: acs
-  policyTypes:
-    - Egress
-  egress:
-    - to:
-        - podSelector:
-            matchLabels:
-              app: sync-service
-      ports:
-        - protocol: TCP
-          port: 9090
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  namespace: {{ .Release.Namespace }}
-  name: acs-to-transform-router
-spec:
-  podSelector:
-    matchLabels:
-      app: acs
-  policyTypes:
-    - Egress
-  egress:
-    - to:
-        - podSelector:
-            matchLabels:
-              app: transform-router
-      ports:
-        - protocol: TCP
-          port: 8095
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  namespace: {{ .Release.Namespace }}
-  name: acs-to-shared-file-store
-spec:
-  podSelector:
-    matchLabels:
-      app: acs
-  policyTypes:
-    - Egress
-  egress:
-    - to:
-        - podSelector:
-            matchLabels:
-              app: shared-file-store
-      ports:
-        - protocol: TCP
-          port: 8099
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  namespace: {{ .Release.Namespace }}
   name: acs-from-solr
 spec:
   podSelector:
@@ -163,28 +109,27 @@ spec:
           port: 8080
         - protocol: TCP
           port: 8443
+{{- if (.Values.syncService.enabled) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: acs-from-share
+  name: acs-to-sync-service
 spec:
   podSelector:
     matchLabels:
       app: acs
   policyTypes:
-    - Ingress
-  ingress:
-    - from:
+    - Egress
+  egress:
+    - to:
         - podSelector:
             matchLabels:
-              app: share
+              app: sync-service
       ports:
         - protocol: TCP
-          port: 8080
-        - protocol: TCP
-          port: 8443
+          port: 9090
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -207,6 +152,76 @@ spec:
           port: 8080
         - protocol: TCP
           port: 8443
+{{- end }}
+{{- if and (.Values.transformServices.enabled) (.Values.transformServices.transformRouter.enabled) (.Values.general.enterprise) }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: acs-to-transform-router
+spec:
+  podSelector:
+    matchLabels:
+      app: acs
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: transform-router
+      ports:
+        - protocol: TCP
+          port: 8095
+{{- end }}}
+{{- if and (.Values.transformServices.enabled) (.Values.transformServices.sharedFileStore.enabled) (.Values.general.enterprise) }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: acs-to-shared-file-store
+spec:
+  podSelector:
+    matchLabels:
+      app: acs
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: shared-file-store
+      ports:
+        - protocol: TCP
+          port: 8099
+{{- end }}
+{{- if and (.Values.share.enabled) (.Values.general.networkPolicies.enabled) }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: acs-from-share
+spec:
+  podSelector:
+    matchLabels:
+      app: acs
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: share
+      ports:
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 8443
+{{- end }}
+{{- if (.Values.ooi.enabled) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -229,5 +244,6 @@ spec:
           port: 8080
         - protocol: TCP
           port: 8443
+{{- end }}
 ---
 {{- end }}

--- a/xenit-alfresco/templates/acs/network-policy.yml
+++ b/xenit-alfresco/templates/acs/network-policy.yml
@@ -174,7 +174,7 @@ spec:
       ports:
         - protocol: TCP
           port: 8095
-{{- end }}}
+{{- end }}
 {{- if and (.Values.transformServices.enabled) (.Values.transformServices.sharedFileStore.enabled) (.Values.general.enterprise) }}
 ---
 apiVersion: networking.k8s.io/v1

--- a/xenit-alfresco/templates/ooi/cilium-network-policy.yml
+++ b/xenit-alfresco/templates/ooi/cilium-network-policy.yml
@@ -1,4 +1,4 @@
-{{- if and (.Values.general.networkPolicies.enabled) (eq .Values.general.cni "cilium") }}
+{{- if and (.Values.general.networkPolicies.enabled) (.Values.general.networkPolicies.cilium.enabled) }}
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:

--- a/xenit-alfresco/templates/ooi/network-policy.yml
+++ b/xenit-alfresco/templates/ooi/network-policy.yml
@@ -1,4 +1,4 @@
-{{- if .Values.general.networkPolicies.enabled }}
+{{- if and (.Values.general.networkPolicies.enabled) (.Values.ooi.enabled) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/xenit-alfresco/templates/postgres/network-policy.yaml
+++ b/xenit-alfresco/templates/postgres/network-policy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.general.networkPolicies.enabled }}
+{{- if and (.Values.general.networkPolicies.enabled) (.Values.postgresql.enabled) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/xenit-alfresco/templates/share/network-policy.yml
+++ b/xenit-alfresco/templates/share/network-policy.yml
@@ -1,4 +1,4 @@
-{{- if .Values.general.networkPolicies.enabled }}
+{{- if and (.Values.share.enabled) (.Values.general.networkPolicies.enabled) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/xenit-alfresco/templates/sync-service/network-policy.yml
+++ b/xenit-alfresco/templates/sync-service/network-policy.yml
@@ -1,4 +1,4 @@
-{{- if .Values.general.networkPolicies.enabled }}
+{{- if and (.Values.general.networkPolicies.enabled) (.Values.syncService.enabled) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -10,6 +10,8 @@ general:
   cni: cilium
   networkPolicies:
     enabled: true
+    cilium:
+      enabled: true
   secrets:
     acs:
       selfManaged: false


### PR DESCRIPTION
cilium netpolls were tied to a 'cni' variable, which was not correct, given that cilium can be chained to other cnis (as is the case for aws)