### PR TITLE
XENOPS-1187 revert disable MQ on community edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ For more information take a look at
 * Required: false
 * Default: true
 * Description: Whether this is an enterprise version of Alfresco. In a community version Transform Service Router, 
-Transform Service Shared File Storage, Clustering (replica count should always have a max of 1 for ACS pods), MQ and 
+Transform Service Shared File Storage, Clustering (replica count should always have a max of 1 for ACS pods) and 
 Digital Workspace are disabled. 
 
 #### `general.hibernate`

--- a/xenit-alfresco/templates/acs/acs-config.yaml
+++ b/xenit-alfresco/templates/acs/acs-config.yaml
@@ -29,8 +29,6 @@ data:
   {{- end }}
   {{- if not (.Values.general.enterprise) }}
   GLOBAL_local.transform.service.enabled: 'true'
-  GLOBAL_messaging.subsystem.autoStart: 'false'
-  GLOBAL_repo.event2.enabled: 'false'
   {{- end}}
   {{- if .Values.transformServices.enabled }}
   GLOBAL_transform.service.enabled: 'true'

--- a/xenit-alfresco/templates/active-mq/mq-config.yaml
+++ b/xenit-alfresco/templates/active-mq/mq-config.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.mq.enabled) (.Values.general.enterprise) -}}
+{{- if .Values.mq.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/xenit-alfresco/templates/active-mq/mq-deployment.yaml
+++ b/xenit-alfresco/templates/active-mq/mq-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.mq.enabled) (.Values.general.enterprise) -}}
+{{- if .Values.mq.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/xenit-alfresco/templates/active-mq/mq-secret.yaml
+++ b/xenit-alfresco/templates/active-mq/mq-secret.yaml
@@ -1,4 +1,4 @@
-{{- if  and (not .Values.general.secrets.mq.selfManaged) (.Values.mq.enabled) (.Values.general.enterprise) }}
+{{- if  and (not .Values.general.secrets.mq.selfManaged) (.Values.mq.enabled) }}
 {{- $secret_name := "mq-secret" }}
 
 apiVersion: v1

--- a/xenit-alfresco/templates/active-mq/mq-service.yaml
+++ b/xenit-alfresco/templates/active-mq/mq-service.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.mq.enabled) (.Values.general.enterprise) -}}
+{{- if .Values.mq.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/xenit-alfresco/templates/active-mq/network-policy.yml
+++ b/xenit-alfresco/templates/active-mq/network-policy.yml
@@ -1,4 +1,4 @@
-{{- if and (.Values.general.networkPolicies.enabled) (.Values.mq.enabled) (.Values.general.enterprise) }}
+{{- if and (.Values.general.networkPolicies.enabled) (.Values.mq.enabled) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
revert of https://github.com/xenit-eu/helm-alfresco/commit/3a06728cbd6b62b84e7b1cfa86697e2efbad5254#diff-9ef0f4efa891d05e19dd019ca85c5a17562dad05294829dca4ff133984bb295dL1

except for 

GLOBAL_local.transform.service.enabled: 'true'

when community edition