### PR TITLE
[NYS2AWS-71] allow node anti-affinity for Solr pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ chronology things are added/fixed/changed and - where possible - links to the PR
 
 ### Changes
 
+[v0.8.2]
+* added solr.enforceHostnameAntiAffinity
+
 [v0.8.0]
 
 * **Potentially breaking change**: changed `alfresco-ingress` definition & default values to enable usage of `ingressClassName` property in favour of `kubernetes.io/ingress.class` annotation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ chronology things are added/fixed/changed and - where possible - links to the PR
 ### Changes
 
 [v0.8.2]
-* added solr.enforceHostnameAntiAffinity
+* added solr.enforceZoneAntiAffinity
 
 [v0.8.0]
 

--- a/README.md
+++ b/README.md
@@ -1330,6 +1330,14 @@ nginx rules to redirect the normal pages to a 503 maintenance page.
   ```
 * Description: With this list of parameters you can add 1 or multiple annotations to the Solr service
 
+#### `solr.enforceHostnameAntiAffinity`
+
+* Required: false
+* Default: false
+* Description: If true, this option enforces a pod anti-affinity on the Solr pods based on the hostnames.
+  I.e. if true, each Solr pod will require a unique node. Starting more pods than nodes will put the
+  remainder pods in a `Pending` state.
+
 #### `solr.serviceAccount`
 
 * Required: false

--- a/README.md
+++ b/README.md
@@ -1337,6 +1337,8 @@ nginx rules to redirect the normal pages to a 503 maintenance page.
 * Description: If true, this option enforces a pod anti-affinity on the Solr pods based on the zones.
   I.e. if true, each Solr pod will require a unique zone. Starting more pods than zones will put the
   remainder pods in a `Pending` state.
+  <br>
+  <b>Please note that switching off the anti-affinity does not alter the anti-affinity of the already running pods!</b>
 
 #### `solr.serviceAccount`
 

--- a/README.md
+++ b/README.md
@@ -1330,12 +1330,12 @@ nginx rules to redirect the normal pages to a 503 maintenance page.
   ```
 * Description: With this list of parameters you can add 1 or multiple annotations to the Solr service
 
-#### `solr.enforceHostnameAntiAffinity`
+#### `solr.enforceZoneAntiAffinity`
 
 * Required: false
 * Default: false
-* Description: If true, this option enforces a pod anti-affinity on the Solr pods based on the hostnames.
-  I.e. if true, each Solr pod will require a unique node. Starting more pods than nodes will put the
+* Description: If true, this option enforces a pod anti-affinity on the Solr pods based on the zones.
+  I.e. if true, each Solr pod will require a unique zone. Starting more pods than zones will put the
   remainder pods in a `Pending` state.
 
 #### `solr.serviceAccount`

--- a/xenit-alfresco/templates/solr/solr-stateful-set.yaml
+++ b/xenit-alfresco/templates/solr/solr-stateful-set.yaml
@@ -30,11 +30,11 @@ spec:
         {{ toYaml .Values.solr.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.solr.enforceHostnameAntiAffinity }}
+      {{- if .Values.solr.enforceZoneAntiAffinity }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: "kubernetes.io/hostname"
+            - topologyKey: "topology.kubernetes.io/zone"
               labelSelector:
                 matchExpressions:
                   - key: "app"

--- a/xenit-alfresco/templates/solr/solr-stateful-set.yaml
+++ b/xenit-alfresco/templates/solr/solr-stateful-set.yaml
@@ -30,6 +30,18 @@ spec:
         {{ toYaml .Values.solr.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.solr.enforceHostnameAntiAffinity }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: "In"
+                    values:
+                      - solr
+      {{- end }}
       {{- if .Values.solr.serviceAccount }}
       serviceAccountName: {{ .Values.solr.serviceAccount }}
       {{- end }}

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -151,6 +151,7 @@ postgresql:
 solr:
   enabled: true
   replicas: 2
+  enforceHostnameAntiAffinity: false
   podManagementPolicy: Parallel
   image:
     registry: 'docker.io'

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -151,7 +151,7 @@ postgresql:
 solr:
   enabled: true
   replicas: 2
-  enforceHostnameAntiAffinity: false
+  enforceZoneAntiAffinity: false
   podManagementPolicy: Parallel
   image:
     registry: 'docker.io'


### PR DESCRIPTION
https://xenitsupport.jira.com/browse/NYS2AWS-71

For DSNY, we need an option to enforce hostname anti-affinity for the Solr pods.
The goal of this PR is to support this functionality.