### PR TITLE
[NYS2AWS-74] enforce quotes for ingress annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ chronology things are added/fixed/changed and - where possible - links to the PR
 
 ### Changes
 
+[v0.8.3]
+* fixed a bug that caused the ingress annotations to miss necessary quotes
+
 [v0.8.2]
 * added solr.enforceZoneAntiAffinity
 

--- a/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
+++ b/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     */ -}}
     {{- range $key, $value := .Values.ingress.ingressAnnotations }}
     {{- if not ( and ($.Values.ingress.ingressClass) (eq $key "kubernetes.io/ingress.class")) }}
-    {{ $key  }}: {{ $value }}
+    {{ $key  }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
     {{- end }}


### PR DESCRIPTION
https://xenitsupport.jira.com/browse/NYS2AWS-74

Version 0.8.0 caused a quote-related problem in regards to the annotations for the ingress.
This version addresses that problem.