### PR TITLE
[XENOPS-1238] SOLR use "find" to delete write.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 chronology things are added/fixed/changed and - where possible - links to the PRs involved.
 
 ### Changes
+[v0.8.5]
+* SOLR, use "find" to delete write.lock  
+After SOLR restore from backup the active index folder could be set to restore.xxxx preventing the removal of write.lock using the standard rm command.  
+ 
 [v0.8.4]
 * do not create a pvc for shared-file-store when enterprise=false
 

--- a/xenit-alfresco/templates/solr/solr-stateful-set.yaml
+++ b/xenit-alfresco/templates/solr/solr-stateful-set.yaml
@@ -67,8 +67,7 @@ spec:
                 command:
                   - /bin/bash
                   - -c
-                  - rm -f /opt/alfresco-search-services/data/index/archive/index/write.lock
-                  - rm -f /opt/alfresco-search-services/data/index/alfresco/index/write.lock
+                  - find /opt/alfresco-search-services/data/index -name write.lock -delete
           envFrom:
             - configMapRef:
                 name: solr-configmap


### PR DESCRIPTION
After a restore from backup the SOLR index folder sometimes points to "restore.xxxx" instead of "index".
In order to remove any remaining write.lock files after restart, the mechanism should find instead of a hardcoded rm <path>