### PR TITLE
[NYS2AWS-125] allow custom alfresco-pv names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 chronology things are added/fixed/changed and - where possible - links to the PRs involved.
 
 ### Changes
+[v0.8.6]
+* Introduced the `persistentStorage.alfresco.name` option to allow for the specification of the PV and PVC name for Alfresco.
+
 [v0.8.5]
 * SOLR, use "find" to delete write.lock  
 After SOLR restore from backup the active index folder could be set to restore.xxxx preventing the removal of write.lock using the standard rm command.  

--- a/README.md
+++ b/README.md
@@ -2155,6 +2155,12 @@ additional settings can be added through additionalEnvironmentVariables.
 * Default: `true`
 * Description: Enable or disable the creation of a PV and PVC for the ACS pods
 
+#### `persistentStorage.alfresco.name`
+
+* Required: false
+* Default: `alfresco`
+* Description: the prefix for the Alfresco PV and PVC; will result in `${PREFIX}-pv` and `${PREFIX}-pvc`.
+
 #### `persistentStorage.alfresco.storageClassName`
 
 * Required: false

--- a/xenit-alfresco/templates/storage/alfresco-volumes.yaml
+++ b/xenit-alfresco/templates/storage/alfresco-volumes.yaml
@@ -1,7 +1,7 @@
 {{- $namespace := .Release.Namespace -}}
 {{- with .Values.persistentStorage.alfresco }}
 {{- if .enabled}}
-{{- $name := "alfresco" -}}
+{{- $name := default "alfresco" .name -}}
 {{- $storageClassName := .storageClassName -}}
 {{- $storage := .storage -}}
 {{- $efsVolumeHandle := .efs.volumeHandle -}}


### PR DESCRIPTION
https://xenitsupport.jira.com/browse/NYS2AWS-125

Problem: PVC's are namespace-specific, but PV's are not (cluster-wide). 
For DSNY, `alfresco-pv` was already used by the development environment. Helm added an annotation to that PV to prevent it from being used by other releases / namespaces. However, since `alfresco-pv` is hardcoded, the staging environment could not be installed.

Solution (discussed with Gert): change the prefix of the PV and PVC so that they default to "alfresco" (for legacy reasons), but allow a custom prefix for other environments.