### PR TITLE
NYS2AWS-121 remove efs storage class

### DIFF
--- a/xenit-alfresco/templates/storage/storage-class.yaml
+++ b/xenit-alfresco/templates/storage/storage-class.yaml
@@ -1,0 +1,7 @@
+{{- if and (.Values.persistentStorage.aws.efs.storageClass.enableIfRequired) (or (eq .Values.persistentStorage.alfresco.storageClassName "efs-storage-class") (eq .Values.persistentStorage.postgres.storageClassName "efs-storage-class") (eq .Values.persistentStorage.solr.storageClassName "efs-storage-class") (eq .Values.persistentStorage.sharedFileStore.storageClassName "efs-storage-class")) -}}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: efs-storage-class
+provisioner: efs.csi.aws.com
+{{- end }}

--- a/xenit-alfresco/templates/storage/storage-class.yaml
+++ b/xenit-alfresco/templates/storage/storage-class.yaml
@@ -1,7 +1,0 @@
-{{- if or (eq .Values.persistentStorage.alfresco.storageClassName "efs-storage-class") (eq .Values.persistentStorage.postgres.storageClassName "efs-storage-class") (eq .Values.persistentStorage.solr.storageClassName "efs-storage-class") (eq .Values.persistentStorage.sharedFileStore.storageClassName "efs-storage-class") -}}
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: efs-storage-class
-provisioner: efs.csi.aws.com
-{{- end }}

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -249,6 +249,10 @@ ooi:
     enabled: true
 
 persistentStorage:
+  aws:
+    efs:
+      storageClass:
+        enableIfRequired: true  # If true, the storage class will be created if a volume with storage class "efs-storage-class" is used.
   alfresco:
     name: alfresco
     enabled: true


### PR DESCRIPTION
https://xenitsupport.jira.com/browse/NYS2AWS-121

Problem: if you install the AWS EFS storage class using `helm-alfresco`, you can only use that storage class in the current namespace.
Creating a new storage class with a different name does not seem to fix this issue, since K8S starts complaining about a missing filesystem ID (i.e., you apparently should create a storage class for each volume).
We also can't completely remove the storage class from `helm-alfresco`, since it's being used by another customer.
Therefore, I decided to make it toggleable.