### PR TITLE
[NYS2AWS-130] allow the specification of the ActiveMQ PV(C) names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 chronology things are added/fixed/changed and - where possible - links to the PRs involved.
 
 ### Changes
+[v0.8.8]
+* Introduced the `persistentStorage.aws.efs.storageClass.enableIfRequired`
+option, which can be used to prevent the AWS `efs-storage-class` from being created.
+* Introduced the `persistentStorage.mq.name` option to specify the name of the ActiveMQ
+PV and PVC.
 
 [v0.8.7]
 * Fixed a bug that caused the Alfresco pod to still use `alfresco-pvc`, even when `persistentStorage.alfresco.name` was set.

--- a/xenit-alfresco/templates/active-mq/mq-deployment.yaml
+++ b/xenit-alfresco/templates/active-mq/mq-deployment.yaml
@@ -127,7 +127,7 @@ spec:
       {{- if .Values.persistentStorage.mq.enabled }}
         - name: data
           persistentVolumeClaim:
-            claimName: mq-pvc
+            claimName: {{ .Values.persistentStorage.mq.name }}-pvc
       {{- end }}
         {{- if .Values.persistentStorage.mq.additionalClaims }}
       {{- range .Values.persistentStorage.mq.additionalClaims }}

--- a/xenit-alfresco/templates/storage/mq-volumes.yaml
+++ b/xenit-alfresco/templates/storage/mq-volumes.yaml
@@ -2,7 +2,7 @@
 {{- $namespace := .Release.Namespace -}}
 {{- with .Values.persistentStorage.mq }}
 {{- if .enabled}}
-{{- $name := "mq" -}}
+{{- $name := .name -}}
 {{- $storageClassName := .storageClassName -}}
 {{- $storage := .storage -}}
 {{- $efsVolumeHandle := .efs.volumeHandle -}}

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -286,6 +286,7 @@ persistentStorage:
     efs:
       volumeHandle: ""
   mq:
+    name: mq
     enabled: true
     initVolumes: true
     storageClassName: ""


### PR DESCRIPTION
https://xenitsupport.jira.com/browse/NYS2AWS-130

Same problem as before with Alfresco: PVC's are namespace-specific, but PV's are not. Enabling ActiveMQ creates a persistent volume `mq-pv` that prevents any other namespace to ever create this PV again.

Solution: allow the name of the ActiveMQ PV and PVC to be specified.