### PR TITLE
[NYS2AWS-143] make cluster issuer optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 chronology things are added/fixed/changed and - where possible - links to the PRs involved.
 
 ### Changes
+[v0.8.9]
+* Introduced the `ingress.clusterIssuer` option to specify the cluster issuer for the ingress.
+
 [v0.8.8]
 * Introduced the `persistentStorage.aws.efs.storageClass.enableIfRequired`
 option, which can be used to prevent the AWS `efs-storage-class` from being created.

--- a/README.md
+++ b/README.md
@@ -268,13 +268,21 @@ nginx rules to redirect the normal pages to a 503 maintenance page.
   Replacement for `kubernetes.io/ingress.class` annotation since it's deprecation in k8s 1.18. 
   Set to `null` to allow usage of `kubernetes.io/ingress.class` in the `ingress.ingressAnnotations` dict.
 
+### `ingress.clusterIssuer`
+
+* Required: true
+* Default: `letsencrypt-production`
+* Description: Reference name for the cert-manager ClusterIssuer to be used. 
+  This is used to request a certificate for the ingress host.
+  This property adds the `cert-manager.io/cluster-issuer` annotation to the ingress.
+  If you don't want a certificate, set this to an empty string.
+
 #### `ingress.ingressAnnotations`
 
 * Required: false
 * Default:
   ```
     kubernetes.io/ingress.class: "nginx"
-    cert-manager.io/cluster-issuer: "letsencrypt-production"
   ```
 * Description: Annotations for ingress.
 * Remarks:
@@ -282,6 +290,8 @@ nginx rules to redirect the normal pages to a 503 maintenance page.
   out if the `ingress.ingressClass` is set (This includes the default value). 
   The `kubernetes.io/ingress.class` is deprecated since k8s v1.18, but some setups still rely on it.
   Hence it can still be set and used if `ingress.ingressClass` is set to `null`.
+  * Do not use this for the `cert-manager.io/cluster-issuer` annotation;
+    use `ingress.clusterIssuer` instead.
 
 #### `ingress.additionalPaths`
 

--- a/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
+++ b/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
@@ -5,6 +5,9 @@ metadata:
   name: alfresco-ingress
   namespace: {{ .Release.Namespace | quote }}
   annotations:
+    {{- if and (.Values.ingress.clusterIssuer) (not (eq .Values.ingress.clusterIssuer "")) }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.clusterIssuer | quote }}
+    {{- end }}
     {{- if .Values.ingress.ingressAnnotations }}
     {{- /*
       See https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -21,11 +21,11 @@ general:
       selfManaged: false
 
 ingress:
+  clusterIssuer: "letsencrypt-production"
   ingressClass: "nginx"
   protocol: 'https'
   ingressAnnotations:
     kubernetes.io/ingress.class: "nginx"
-    cert-manager.io/cluster-issuer: "letsencrypt-production"
   defaultPath:
     service: nginx-default-service
     port: 30403


### PR DESCRIPTION
AWS-related problem: if you want to use self-signed certificates with your ALB load balancer (which is the case with OTI/DSNY), you need to add the certificate to AWS' Certificate Manager. You don't need to add the certificate as a K8S resource separately.
Problem: if you set the cluster issuer on the Ingress resource to some value, a certificate is automatically created, even if the issuer does not exist. The certificate never gets ready, though.

Solution: make the cluster issuer optional, but default to `letsencrypt-production` for compatibility reasons.