### PR TITLE
KANSUP74-37 add configurable port for acs inbound email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 chronology things are added/fixed/changed and - where possible - links to the PRs involved.
 
 ### Changes
+[v0.8.10]
+* Make port for inbound email on acs configurable
+
 [v0.8.9]
 * Introduced the `ingress.clusterIssuer` option to specify the cluster issuer for the ingress.
 

--- a/README.md
+++ b/README.md
@@ -479,6 +479,13 @@ ingress:
 * Default: `https`
 * Description: Set to overwrite the share protocol
 
+#### `acs.email.inbound.port`
+
+* Required: false
+* Default: None
+* Description: Set given port for inbound mail in the acs config and expose it in the acs-service & deployment. 
+* **Warning**: Setting only this port does not enable the system. Enabling requires additional acs config (see alfresco documentation) and configuration of the ingress (see applicable ingress documentation)
+
 #### `acs.additionalEnvironmentVariables`
 
 * Required: false

--- a/xenit-alfresco/Chart.yaml
+++ b/xenit-alfresco/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.5
+version: 0.8.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/xenit-alfresco/templates/acs/acs-config.yaml
+++ b/xenit-alfresco/templates/acs/acs-config.yaml
@@ -48,6 +48,9 @@ data:
   {{- if not .Values.solr.enabled }}
   GLOBAL_index.subsystem.name: "noindex"
   {{- end }}
+  {{- if ((((.Values.acs).email).inbound).port) }}
+  GLOBAL_email.server.port: {{ .Values.acs.email.inbound.port }}
+  {{- end }}
   {{- if .Values.acs.additionalEnvironmentVariables }}
   {{ toYaml .Values.acs.additionalEnvironmentVariables | nindent 2 }}
   {{- end }}

--- a/xenit-alfresco/templates/acs/acs-deployment.yaml
+++ b/xenit-alfresco/templates/acs/acs-deployment.yaml
@@ -91,6 +91,10 @@ spec:
             protocol: TCP
           - containerPort: 8443
             protocol: TCP
+          {{- if ((((.Values.acs).email).inbound).port) }}
+          - containerPort: {{ .Values.acs.email.inbound.port }}
+            protocol: TCP
+          {{- end }}
         {{- if or (.Values.acs.resources.requests) ((.Values.acs.resources.limits)) }}
         resources:
           {{- if .Values.acs.resources.requests }}

--- a/xenit-alfresco/templates/acs/acs-service.yaml
+++ b/xenit-alfresco/templates/acs/acs-service.yaml
@@ -20,6 +20,11 @@ spec:
         protocol: TCP
         port: 8443
         targetPort: 8443
+    {{- if ((((.Values.acs).email).inbound).port) }}
+      - name: 'acs-inbound-smtp'
+        protocol: TCP
+        port: {{ .Values.acs.email.inbound.port }}
+    {{- end }}
   {{- if .Values.general.serviceType }}
   type: {{ .Values.general.serviceType }}
   {{- end }}

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -36,6 +36,7 @@ ingress:
       - /alfresco/service/api/solr
       - /alfresco/wcs/api/solr
       - /alfresco/wcservice/api/solr
+
 acs:
   replicas: 1
   image:
@@ -76,6 +77,7 @@ acs:
   customReadinessProbe:
   ingress:
     enabled: true
+
 digitalWorkspace:
   enabled: true
   replicas: 1
@@ -92,6 +94,7 @@ digitalWorkspace:
   basePath: "/workspace"
   ingress:
     enabled: true
+
 share:
   enabled: true
   mergeAcsShare: false
@@ -174,6 +177,7 @@ solr:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 10
+
 transformServices:
   enabled: true
   sharedFileStore:


### PR DESCRIPTION
Sets a port for the acs inbound email system on the acs deployment and service, and injects it in the configmap for acs.

Ingress config is not included since it depends on the ingress implementation and installation. 
(eg nginx addon requires changes in the daemonset & configmap, nginx chart requires custom resource.)