### PR TITLE
[NYS2AWS-146] add support for custom ActiveMQ init. container image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 chronology things are added/fixed/changed and - where possible - links to the PRs involved.
 
 ### Changes
+[v0.8.12]
+* Added support for custom ActiveMQ init. container images.
+
 [v0.8.11]
 * uncouple port for inbound email on acs pod and acs service
 

--- a/README.md
+++ b/README.md
@@ -1019,6 +1019,24 @@ ingress:
 * Default: `1`
 * Description: The number of pods that will be running
 
+#### `mq.init.image.registry`
+
+* Required: false
+* Default: `docker.io`
+* Description: The registry where the docker container can be found in
+
+#### `mq.init.image.repository`
+* 
+* Required: false
+* Default: `busybox`
+* Description: The repository of the docker image that will be used
+
+#### `mq.init.image.tag`
+
+* Required: false
+* Default: `1.35.0`
+* Description: The tag of the docker image that will be used
+
 #### `mq.image.registry`
 
 * Required: false

--- a/xenit-alfresco/templates/active-mq/mq-deployment.yaml
+++ b/xenit-alfresco/templates/active-mq/mq-deployment.yaml
@@ -101,7 +101,7 @@ spec:
       {{- if .Values.persistentStorage.mq.initVolumes }}
       initContainers:
         - name: init-fs
-          image: "busybox:1.35.0"
+          image: {{ .Values.mq.init.image.registry }}/{{ .Values.mq.init.image.repository }}:{{ .Values.mq.init.image.tag }}
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -131,6 +131,11 @@ mq:
     registry: 'docker.io'
     repository: 'alfresco/alfresco-activemq'
     tag: '5.18.3-jre17-rockylinux8@sha256:25386b20263b7e838605e07fea2713fb65762010c1c677cf82aecefbaed5d227'
+  init:
+    image:
+      registry: 'docker.io'
+      repository: 'busybox'
+      tag: '1.35.0'
   strategy:
     type: Recreate
   resources:


### PR DESCRIPTION
https://xenitsupport.jira.com/browse/NYS2AWS-146

DSNY's proxy is acting up again, so it's not always possible to fetch the `busybox` image.
Solution: make the image registry / repository / tag configurable so that we can refer to their own Artifactory.