### PR TITLE
[NYS2AWS-147] added support for custom NGINX image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 chronology things are added/fixed/changed and - where possible - links to the PRs involved.
 
 ### Changes
+[v0.8.13]
+* Added support for custom NGINX container image.
+
 [v0.8.12]
-* Added support for custom ActiveMQ init. container images.
+* Added support for custom ActiveMQ init. container image.
 
 [v0.8.11]
 * uncouple port for inbound email on acs pod and acs service

--- a/README.md
+++ b/README.md
@@ -277,6 +277,25 @@ nginx rules to redirect the normal pages to a 503 maintenance page.
   This property adds the `cert-manager.io/cluster-issuer` annotation to the ingress.
   If you don't want a certificate, set this to an empty string.
 
+### `ingress.nginx.image.registry`
+
+* Required: false
+* Default: `docker.io`
+* Description: The registry where the docker container can be found in
+
+
+### `ingress.nginx.image.repository`
+
+* Required: false
+* Default: `nginx`
+* Description: The repository of the docker image that will be used
+
+### `ingress.nginx.image.tag`
+
+* Required: false
+* Default: `alpine`
+* Description: The tag of the docker image that will be used
+
 #### `ingress.ingressAnnotations`
 
 * Required: false

--- a/xenit-alfresco/templates/ingress/nginx-default-deployment.yaml
+++ b/xenit-alfresco/templates/ingress/nginx-default-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:alpine
+          image: {{ .Values.ingress.nginx.image.registry }}/{{ .Values.ingress.nginx.image.repository }}:{{ .Values.ingress.nginx.image.tag }}
           ports:
             - containerPort: 80
           volumeMounts:

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -24,6 +24,11 @@ ingress:
   clusterIssuer: "letsencrypt-production"
   ingressClass: "nginx"
   protocol: 'https'
+  nginx:
+    image:
+      registry: 'docker.io'
+      repository: 'nginx'
+      tag: 'alpine'
   ingressAnnotations:
     kubernetes.io/ingress.class: "nginx"
   defaultPath:


### PR DESCRIPTION
https://xenitsupport.jira.com/browse/NYS2AWS-147

I'm trying to fix this, which is caused by OTI's problematic proxy setup:

![Schermafdruk van 2025-02-11 09-31-59](https://github.com/user-attachments/assets/c120c0a4-ccf5-4c8e-a27c-2ead0d1415d5)
