### PR TITLE
NYS2AWS-192: Allow multiple ingress hostnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 chronology things are added/fixed/changed and - where possible - links to the PRs involved.
 
 ### Changes
-[v0.8.14]
+[v0.8.16]
 * Introduced the `ingress.hosts` property that can be used to specify multiple hostnames for the ingress configuration.
   `ingress.host` can still be used for a single hostname.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 chronology things are added/fixed/changed and - where possible - links to the PRs involved.
 
 ### Changes
+[v0.8.14]
+* Introduced the `ingress.hosts` property that can be used to specify multiple hostnames for the ingress configuration.
+  `ingress.host` can still be used for a single hostname.
+
 [v0.8.13]
 * Added support for custom NGINX container image.
 

--- a/README.md
+++ b/README.md
@@ -250,9 +250,19 @@ nginx rules to redirect the normal pages to a 503 maintenance page.
 
 #### `ingress.host`
 
-* Required: true
+* Required: if `ingress.hosts` is an empty list
 * Default: None
-* Description: The host that points to the alfresco cluster for all services besides the syncService service
+* Description: The host that points to the alfresco cluster for all services besides the syncService service.
+  Although this is not recommended, this property can be combined with the `ingress.hosts` property. 
+  In that case, the hostnames will be combined.
+
+#### `ingress.hosts`
+
+* Required: if `ingress.host` is None
+* Default: empty list
+* Description: The hosts that point to the alfresco cluster for all services besides the syncService service.
+  This property can be combined with the `ingress.host` property. In that case, the hostnames will be combined.
+
 
 #### `ingress.syncServiceHost`
 

--- a/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
+++ b/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
@@ -58,12 +58,11 @@ spec:
         number: {{ .Values.ingress.defaultBackend.port }}
   {{- end }}
   rules:
-  {{- $values := .Values }} # We will break the reference to .Values on the next line (until we escape the range).
   {{- range $allAlfrescoHostNames }}
   - host: {{ . | quote }}
     http:
       paths:
-      {{- if $values.general.hibernate }}
+      {{- if $.Values.general.hibernate }}
       - path: /
         pathType: Prefix
         backend:
@@ -71,16 +70,16 @@ spec:
             name: nginx-default-service
             port:
               number: 30403
-      {{- else if $values.ingress.defaultPath }}
+      {{- else if $.Values.ingress.defaultPath }}
       - path: /
         pathType: Prefix
         backend:
           service:
-            name: {{ $values.ingress.defaultPath.service }}
+            name: {{ $.Values.ingress.defaultPath.service }}
             port:
-              number: {{ $values.ingress.defaultPath.port }}
+              number: {{ $.Values.ingress.defaultPath.port }}
       {{- end }}
-      {{- if and $values.acs.ingress.enabled (not $values.general.hibernate) }}
+      {{- if and $.Values.acs.ingress.enabled (not $.Values.general.hibernate) }}
       - path: /alfresco
         pathType: Prefix
         backend:
@@ -89,7 +88,7 @@ spec:
             port:
               number: 30000
       {{- end }}
-      {{- if and $values.share.enabled $values.share.ingress.enabled (not $values.general.hibernate) }}
+      {{- if and $.Values.share.enabled $.Values.share.ingress.enabled (not $.Values.general.hibernate) }}
       - path: /share
         pathType: Prefix
         backend:
@@ -98,8 +97,8 @@ spec:
             port:
               number: 30100
       {{- end }}
-      {{- if and $values.digitalWorkspace.enabled $values.digitalWorkspace.ingress.enabled (not $values.general.hibernate) }}
-      - path: {{ $values.digitalWorkspace.basePath }}
+      {{- if and $.Values.digitalWorkspace.enabled $.Values.digitalWorkspace.ingress.enabled (not $.Values.general.hibernate) }}
+      - path: {{ $.Values.digitalWorkspace.basePath }}
         pathType: Prefix
         backend:
           service:
@@ -107,7 +106,7 @@ spec:
             port:
               number: 30200
       {{- end }}
-      {{- if and $values.ooi.enabled $values.ooi.ingress.enabled (not $values.general.hibernate) }}
+      {{- if and $.Values.ooi.enabled $.Values.ooi.ingress.enabled (not $.Values.general.hibernate) }}
       - path: /ooi-service
         pathType: Prefix
         backend:
@@ -116,8 +115,8 @@ spec:
             port:
               number: 30500
       {{- end }}
-      {{- if $values.ingress.blockedPaths.enabled }}
-      {{- range $values.ingress.blockedPaths.paths }}
+      {{- if $.Values.ingress.blockedPaths.enabled }}
+      {{- range $.Values.ingress.blockedPaths.paths }}
       - path: {{ . }}
         pathType: Prefix
         backend:
@@ -127,10 +126,10 @@ spec:
               number: 30403
       {{- end }}
       {{- end }}
-      {{- if and $values.ingress.additionalPaths (not $values.general.hibernate) }}
-      {{ toYaml $values.ingress.additionalPaths | nindent 6 }}
+      {{- if and $.Values.ingress.additionalPaths (not $.Values.general.hibernate) }}
+      {{ toYaml $.Values.ingress.additionalPaths | nindent 6 }}
       {{- end }}
-  {{- end }} # End of range. We can use .Values again.
+  {{- end }}
   {{- if and .Values.syncService.enabled (not .Values.general.hibernate) }}
   - host: {{ required "If sync Services are enabled a specific host for sync services must be specified in values.ingress.syncServiceHost" .Values.ingress.syncServiceHost }}
     http:

--- a/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
+++ b/xenit-alfresco/templates/ingress/alfresco-ingress.yaml
@@ -1,4 +1,16 @@
 # Defines the deployment for the alfresco content repository app
+
+# Collect all host names.
+{{- $allAlfrescoHostNames := .Values.ingress.hosts }}
+## Add support for the legacy ingress.host property.
+{{- if .Values.ingress.host }}
+  {{- $allAlfrescoHostNames = append $allAlfrescoHostNames .Values.ingress.host }}
+{{- end }}
+## At least one Alfresco hostname should be specified.
+{{- if eq (len $allAlfrescoHostNames) 0}}
+  {{- fail "No host specified for the Alfresco Ingress controller. Please specify the 'values.ingress.hosts' property (list of hostnames)." }}
+{{- end }}
+
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -29,7 +41,9 @@ spec:
   tls:
     - hosts:
         # Provide the desired host
-        - {{ required "A host where your alfresco services can be reached on must be specified in values.ingress.host" .Values.ingress.host }}
+        {{- range $allAlfrescoHostNames}}
+        - {{ . | quote }}
+        {{- end }}
         {{- if .Values.syncService.enabled }}
         - {{ required "If sync Services are enabled a specific host for sync services must be specified in values.ingress.syncServiceHost" .Values.ingress.syncServiceHost }}
         {{- end }}
@@ -44,10 +58,12 @@ spec:
         number: {{ .Values.ingress.defaultBackend.port }}
   {{- end }}
   rules:
-  - host: {{ required "A host where your alfresco services can be reached on must be specified in values.ingress.host" .Values.ingress.host }}
+  {{- $values := .Values }} # We will break the reference to .Values on the next line (until we escape the range).
+  {{- range $allAlfrescoHostNames }}
+  - host: {{ . | quote }}
     http:
       paths:
-      {{- if .Values.general.hibernate }}
+      {{- if $values.general.hibernate }}
       - path: /
         pathType: Prefix
         backend:
@@ -55,16 +71,16 @@ spec:
             name: nginx-default-service
             port:
               number: 30403
-      {{- else if .Values.ingress.defaultPath }}
+      {{- else if $values.ingress.defaultPath }}
       - path: /
         pathType: Prefix
         backend:
           service:
-            name: {{ .Values.ingress.defaultPath.service }}
+            name: {{ $values.ingress.defaultPath.service }}
             port:
-              number: {{ .Values.ingress.defaultPath.port }}
+              number: {{ $values.ingress.defaultPath.port }}
       {{- end }}
-      {{- if and .Values.acs.ingress.enabled (not .Values.general.hibernate) }}
+      {{- if and $values.acs.ingress.enabled (not $values.general.hibernate) }}
       - path: /alfresco
         pathType: Prefix
         backend:
@@ -73,7 +89,7 @@ spec:
             port:
               number: 30000
       {{- end }}
-      {{- if and .Values.share.enabled .Values.share.ingress.enabled (not .Values.general.hibernate) }}
+      {{- if and $values.share.enabled $values.share.ingress.enabled (not $values.general.hibernate) }}
       - path: /share
         pathType: Prefix
         backend:
@@ -82,8 +98,8 @@ spec:
             port:
               number: 30100
       {{- end }}
-      {{- if and .Values.digitalWorkspace.enabled .Values.digitalWorkspace.ingress.enabled (not .Values.general.hibernate) }}
-      - path: {{ .Values.digitalWorkspace.basePath }}
+      {{- if and $values.digitalWorkspace.enabled $values.digitalWorkspace.ingress.enabled (not $values.general.hibernate) }}
+      - path: {{ $values.digitalWorkspace.basePath }}
         pathType: Prefix
         backend:
           service:
@@ -91,7 +107,7 @@ spec:
             port:
               number: 30200
       {{- end }}
-      {{- if and .Values.ooi.enabled .Values.ooi.ingress.enabled (not .Values.general.hibernate) }}
+      {{- if and $values.ooi.enabled $values.ooi.ingress.enabled (not $values.general.hibernate) }}
       - path: /ooi-service
         pathType: Prefix
         backend:
@@ -100,8 +116,8 @@ spec:
             port:
               number: 30500
       {{- end }}
-      {{- if .Values.ingress.blockedPaths.enabled }}
-      {{- range .Values.ingress.blockedPaths.paths }}
+      {{- if $values.ingress.blockedPaths.enabled }}
+      {{- range $values.ingress.blockedPaths.paths }}
       - path: {{ . }}
         pathType: Prefix
         backend:
@@ -111,9 +127,10 @@ spec:
               number: 30403
       {{- end }}
       {{- end }}
-      {{- if and .Values.ingress.additionalPaths (not .Values.general.hibernate) }}
-      {{ toYaml .Values.ingress.additionalPaths | nindent 6 }}
+      {{- if and $values.ingress.additionalPaths (not $values.general.hibernate) }}
+      {{ toYaml $values.ingress.additionalPaths | nindent 6 }}
       {{- end }}
+  {{- end }} # End of range. We can use .Values again.
   {{- if and .Values.syncService.enabled (not .Values.general.hibernate) }}
   - host: {{ required "If sync Services are enabled a specific host for sync services must be specified in values.ingress.syncServiceHost" .Values.ingress.syncServiceHost }}
     http:

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -21,6 +21,7 @@ general:
       selfManaged: false
 
 ingress:
+  hosts: [] # Note: you can still use the legacy 'host' property instead; cf. alfresco-ingress.yaml.
   clusterIssuer: "letsencrypt-production"
   ingressClass: "nginx"
   protocol: 'https'


### PR DESCRIPTION
https://xenitsupport.jira.com/browse/NYS2AWS-192

The problem is that DSNY wants two hostnames to point to the Alfresco ingress.
The first one is a generic ecm.dsnyad.nycnet. This one is currently still pointing to the old production servers; however, at production day, they want to update this one to also point to our ingress.
The second one is the specific ecmaws-prod.dsnyad.nycnet, which we are already currently using.

To limit the impact of switching hostnames during production day, I want to modify the ingress resource, so that it can listen to multiple hostnames.