### PR TITLE
[NYS2AWS-198] Fixed hosts bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 chronology things are added/fixed/changed and - where possible - links to the PRs involved.
 
 ### Changes
+[v0.8.17]
+* Fixed a bug that caused the `SHARE_HOST` and `GLOBAL_aos.baseUrlOverwrite` properties
+  in the `acs-config.yaml`, and the `ALFRESCO_HOST` property in the `share-config.yaml` config files to be
+  malformed when using the `ingress.hosts` property instead of `ingress.host`.
+
 [v0.8.16]
 * Introduced the `ingress.hosts` property that can be used to specify multiple hostnames for the ingress configuration.
   `ingress.host` can still be used for a single hostname.

--- a/README.md
+++ b/README.md
@@ -254,7 +254,10 @@ nginx rules to redirect the normal pages to a 503 maintenance page.
 * Default: None
 * Description: The host that points to the alfresco cluster for all services besides the syncService service.
   Although this is not recommended, this property can be combined with the `ingress.hosts` property. 
-  In that case, the hostnames will be combined.
+  In that case, the hostnames will be combined. Cf. `ingress.hosts` property.
+  <br>⚠️ <b>Note:</b> this value is used to configure the `SHARE_HOST` and `GLOBAL_aos.baseUrlOverwrite` properties 
+  in the `acs-config.yaml`, and the `ALFRESCO_HOST` property in the `share-config.yaml` config files.
+  This mechanism only works if `ingress.hosts` is an empty list, however.
 
 #### `ingress.hosts`
 
@@ -262,6 +265,10 @@ nginx rules to redirect the normal pages to a 503 maintenance page.
 * Default: empty list
 * Description: The hosts that point to the alfresco cluster for all services besides the syncService service.
   This property can be combined with the `ingress.host` property. In that case, the hostnames will be combined.
+  <br>⚠️ <b>Note:</b> only the first element in this list will be used to configure the `SHARE_HOST` and
+  `GLOBAL_aos.baseUrlOverwrite` properties in the `acs-config.yaml`, and the `ALFRESCO_HOST` property in the
+  `share-config.yaml` config files.
+  If this list is empty, the `ingress.host` property will be used instead.
 
 
 #### `ingress.syncServiceHost`

--- a/xenit-alfresco/templates/acs/acs-config.yaml
+++ b/xenit-alfresco/templates/acs/acs-config.yaml
@@ -1,3 +1,17 @@
+# Collect all host names.
+{{- $allHostNames := .Values.ingress.hosts }}
+## Add support for the legacy ingress.host property.
+{{- if .Values.ingress.host }}
+  {{- $allHostNames = append $allHostNames .Values.ingress.host }}
+{{- end }}
+## At least one Alfresco hostname should be specified.
+{{- if eq (len $allHostNames) 0}}
+  {{ fail "No hostname specified. Please specify the 'values.ingress.hosts' property (list of hostnames)." }}
+{{- end }}
+
+# Use the first host name as the default host name.
+{{- $defaultHostName := index $allHostNames 0 }}
+
 {{- if and .Values.elastic.enabled .Values.solr.enabled }}
   {{ fail "Both SOLR and elastic search systems are enabled, you can only have 1 (or none) enabled." }}
 {{- end }}
@@ -13,7 +27,7 @@ data:
   DB_URL: {{ quote .Values.acs.dbUrl }}
   DB_DRIVER: {{ quote .Values.acs.dbDriver }}
   {{- if .Values.share.enabled }}
-  SHARE_HOST: {{ quote .Values.ingress.host }}
+  SHARE_HOST: {{ quote $defaultHostName }}
   SHARE_PORT: {{ quote .Values.acs.sharePort }}
   SHARE_PROTOCOL: {{ quote .Values.acs.shareProtocol }}
   {{- end }}
@@ -44,7 +58,7 @@ data:
   {{- else }}
   GLOBAL_transform.service.enabled: 'false'
   {{- end }}
-  GLOBAL_aos.baseUrlOverwrite: '{{ .Values.ingress.syncServiceHost }}://{{ .Values.ingress.host }}/alfresco/aos'
+  GLOBAL_aos.baseUrlOverwrite: '{{ .Values.ingress.syncServiceHost }}://{{ $defaultHostName }}/alfresco/aos'
   {{- if .Values.solr.enabled }}
   GLOBAL_index.subsystem.name: "solr6"
   GLOBAL_solr.port: '30300'

--- a/xenit-alfresco/templates/share/share-config.yaml
+++ b/xenit-alfresco/templates/share/share-config.yaml
@@ -1,3 +1,17 @@
+# Collect all host names.
+{{- $allHostNames := .Values.ingress.hosts }}
+## Add support for the legacy ingress.host property.
+{{- if .Values.ingress.host }}
+  {{- $allHostNames = append $allHostNames .Values.ingress.host }}
+{{- end }}
+## At least one Alfresco hostname should be specified.
+{{- if eq (len $allHostNames) 0}}
+  {{ fail "No hostname specified. Please specify the 'values.ingress.hosts' property (list of hostnames)." }}
+{{- end }}
+
+# Use the first host name as the default host name.
+{{- $defaultHostName := index $allHostNames 0 }}
+
 {{- if .Values.share.enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -14,7 +28,7 @@ data:
   ALFRESCO_INTERNAL_HOST: 'acs-service'
   ALFRESCO_INTERNAL_PORT: '30000'
   {{- end }}
-  ALFRESCO_HOST: {{ .Values.ingress.host }}
+  ALFRESCO_HOST: {{ quote $defaultHostName }}
   ALFRESCO_PORT: '443'
   ALFRESCO_PROTOCOL: 'https'
   {{- if .Values.share.mergeAcsShare }}


### PR DESCRIPTION
https://xenitsupport.jira.com/browse/NYS2AWS-198

With the previous release, I introduced functionality that allows you to specify multiple hostnames for the ingress controller by using the `.Values.ingress.hosts` property.
However, I wasn't aware that the `.Values.ingress.host` property was used in the ACS and Share ConfigMaps. Therefore, if you would've tried to use `.Values.ingress.hosts` over `.Values.ingress.host`, the ConfigMaps wouldn't be properly configured. This is a bug fix for that problem.