### PR TITLE
[DSNYHD-80] Make ACS hostname anti-affinity optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ chronology things are added/fixed/changed and - where possible - links to the PR
 
 ### Changes
 
+[v0.8.21]
+* Made node hostname anti-affinity optional for ACS deployment pods via `acs.hostnameAntiAffinity.enabled` configuration option (defaults to `true`).
+
 [v0.8.20]
 * Added support for custom Solr backup Docker images.
 

--- a/README.md
+++ b/README.md
@@ -495,6 +495,12 @@ ingress:
 * Default: `RollingUpdate`
 * Description: Can be set to `Recreate` if you want all your pods to be killed before new ones are created
 
+#### `acs.hostnameAntiAffinity.enabled`
+
+* Required: false
+* Default: `true`
+* Description: Enable or disable pod anti-affinity rules for ACS pods. When enabled, ACS pods will be scheduled on different nodes to improve availability and fault tolerance.
+
 #### `acs.dbUrl`
 
 * Required: false

--- a/xenit-alfresco/Chart.yaml
+++ b/xenit-alfresco/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.18
+version: 0.8.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/xenit-alfresco/templates/acs/acs-deployment.yaml
+++ b/xenit-alfresco/templates/acs/acs-deployment.yaml
@@ -51,6 +51,7 @@ spec:
       serviceAccountName: {{ .Values.acs.serviceAccount }}
       {{- end }}
 
+      {{- if .Values.acs.hostnameAntiAffinity.enabled }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -58,6 +59,7 @@ spec:
                 matchLabels:
                   app: acs
               topologyKey: "kubernetes.io/hostname"
+      {{- end }}
       containers:
       - name: acs-container
         image: {{ .Values.acs.image.registry }}/{{ .Values.acs.image.repository }}:{{ .Values.acs.image.tag }}

--- a/xenit-alfresco/values.yaml
+++ b/xenit-alfresco/values.yaml
@@ -55,6 +55,8 @@ acs:
     tag: '7.3.0'
   strategy:
     type: RollingUpdate
+  hostnameAntiAffinity:
+    enabled: true
   resources:
     requests:
       memory: "2Gi"


### PR DESCRIPTION
https://xenitsupport.jira.com/browse/DSNYHD-80

Not actually caused by DSNYHD-80, but was noticed while upgrading the Helm charts in the DSNY project.

Node anti-affinity does not make sense if ACS is not clustered, and only adds more constraints on ACS redeployments. Therefore, we make it optional here.