### PR TITLE
DSYNHD-85: Add option for priority class references

### DIFF
--- a/xenit-alfresco/Chart.yaml
+++ b/xenit-alfresco/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.21
+version: 0.8.23
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/xenit-alfresco/templates/acs/acs-deployment.yaml
+++ b/xenit-alfresco/templates/acs/acs-deployment.yaml
@@ -50,7 +50,6 @@ spec:
       {{- if .Values.acs.serviceAccount }}
       serviceAccountName: {{ .Values.acs.serviceAccount }}
       {{- end }}
-
       {{- if .Values.acs.hostnameAntiAffinity.enabled }}
       affinity:
         podAntiAffinity:
@@ -59,6 +58,9 @@ spec:
                 matchLabels:
                   app: acs
               topologyKey: "kubernetes.io/hostname"
+      {{- end }}
+      {{- if .Values.acs.priorityClassName }}
+      priorityClassName: {{ .Values.acs.priorityClassName }}
       {{- end }}
       containers:
       - name: acs-container

--- a/xenit-alfresco/templates/active-mq/mq-deployment.yaml
+++ b/xenit-alfresco/templates/active-mq/mq-deployment.yaml
@@ -36,6 +36,9 @@ spec:
         {{ toYaml .Values.mq.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.mq.priorityClassName }}
+      priorityClassName: {{ .Values.mq.priorityClassName }}
+      {{- end }}
       containers:
         - name: activemq
           image: {{ .Values.mq.image.registry }}/{{ .Values.mq.image.repository }}:{{ .Values.mq.image.tag }}

--- a/xenit-alfresco/templates/digital-workspace/digital-workspace-deployment.yaml
+++ b/xenit-alfresco/templates/digital-workspace/digital-workspace-deployment.yaml
@@ -35,6 +35,9 @@ spec:
         {{ toYaml .Values.digitalWorkspace.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.digitalWorkspace.priorityClassName }}
+      priorityClassName: {{ .Values.digitalWorkspace.priorityClassName }}
+      {{- end }}
       containers:
         - name: digital-workspace-container
           image: {{ .Values.digitalWorkspace.image.registry }}/{{ .Values.digitalWorkspace.image.repository }}:{{ .Values.digitalWorkspace.image.tag }}

--- a/xenit-alfresco/templates/ingress/nginx-default-deployment.yaml
+++ b/xenit-alfresco/templates/ingress/nginx-default-deployment.yaml
@@ -19,6 +19,9 @@ spec:
       labels:
         app: nginx-default
     spec:
+      {{- if .Values.ingress.nginx.priorityClassName }}
+      priorityClassName: {{ .Values.ingress.nginx.priorityClassName }}
+      {{- end }}
       containers:
         - name: nginx
           image: {{ .Values.ingress.nginx.image.registry }}/{{ .Values.ingress.nginx.image.repository }}:{{ .Values.ingress.nginx.image.tag }}

--- a/xenit-alfresco/templates/ooi/ooi-deployment.yaml
+++ b/xenit-alfresco/templates/ooi/ooi-deployment.yaml
@@ -34,6 +34,9 @@ spec:
       labels:
         app: ooi
     spec:
+      {{- if .Values.ooi.priorityClassName }}
+      priorityClassName: {{ .Values.ooi.priorityClassName }}
+      {{- end }}
       containers:
         - name: ooi-container
           image: {{ .Values.ooi.image.registry }}/{{ .Values.ooi.image.repository }}:{{ .Values.ooi.image.tag }}

--- a/xenit-alfresco/templates/postgres/postgresql-deployment.yaml
+++ b/xenit-alfresco/templates/postgres/postgresql-deployment.yaml
@@ -36,6 +36,9 @@ spec:
         {{ toYaml .Values.postgresql.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.postgresql.priorityClassName }}
+      priorityClassName: {{ .Values.postgresql.priorityClassName }}
+      {{- end }}
       containers:
       - name: postgresql-container
         image: {{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}

--- a/xenit-alfresco/templates/share/share-deployment.yaml
+++ b/xenit-alfresco/templates/share/share-deployment.yaml
@@ -35,6 +35,9 @@ spec:
         {{ toYaml .Values.share.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.share.priorityClassName }}
+      priorityClassName: {{ .Values.share.priorityClassName }}
+      {{- end }}
       containers:
       - name: share-container
         image: {{ .Values.share.image.registry }}/{{ .Values.share.image.repository }}:{{ .Values.share.image.tag }}

--- a/xenit-alfresco/templates/solr/solr-backup/solr-backup-cron.yml
+++ b/xenit-alfresco/templates/solr/solr-backup/solr-backup-cron.yml
@@ -17,6 +17,9 @@ spec:
           labels:
             app: solr-backup-cron-job
         spec:
+          {{- if .Values.solr.autoBackup.priorityClassName }}
+          priorityClassName: {{ .Values.solr.autoBackup.priorityClassName }}
+          {{- end }}
           containers:
             - name: curlimage
               image: {{ .Values.solr.autoBackup.image.registry }}/{{ .Values.solr.autoBackup.image.repository }}@{{ .Values.solr.autoBackup.image.digest }}

--- a/xenit-alfresco/templates/solr/solr-pdb.yaml
+++ b/xenit-alfresco/templates/solr/solr-pdb.yaml
@@ -1,0 +1,12 @@
+{{- if and (.Values.solr.enabled) (gt .Values.solr.replicas 1.0) -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: solr-pdb
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: solr
+{{- end }}

--- a/xenit-alfresco/templates/solr/solr-stateful-set.yaml
+++ b/xenit-alfresco/templates/solr/solr-stateful-set.yaml
@@ -45,6 +45,9 @@ spec:
       {{- if .Values.solr.serviceAccount }}
       serviceAccountName: {{ .Values.solr.serviceAccount }}
       {{- end }}
+      {{- if .Values.solr.priorityClassName }}
+      priorityClassName: {{ .Values.solr.priorityClassName }}
+      {{- end }}
       containers:
         - name: solr-container
           image: {{ .Values.solr.image.registry }}/{{ .Values.solr.image.repository }}:{{ .Values.solr.image.tag }}

--- a/xenit-alfresco/templates/sync-service/sync-service-deployment.yaml
+++ b/xenit-alfresco/templates/sync-service/sync-service-deployment.yaml
@@ -37,6 +37,9 @@ spec:
         {{ toYaml .Values.syncService.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.syncService.priorityClassName }}
+      priorityClassName: {{ .Values.syncService.priorityClassName }}
+      {{- end }}
       containers:
         - name: sync-service-container
           image: {{ .Values.syncService.image.registry }}/{{ .Values.syncService.image.repository }}:{{ .Values.syncService.image.tag }}

--- a/xenit-alfresco/templates/sync-service/sync-service-pdb.yaml
+++ b/xenit-alfresco/templates/sync-service/sync-service-pdb.yaml
@@ -1,0 +1,12 @@
+{{- if and (.Values.syncService.enabled) (gt .Values.syncService.replicas 1.0) -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: sync-service-pdb
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: sync-service
+{{- end }}

--- a/xenit-alfresco/templates/transform-services/shared-file-store/shared-file-store-deployment.yaml
+++ b/xenit-alfresco/templates/transform-services/shared-file-store/shared-file-store-deployment.yaml
@@ -35,6 +35,9 @@ spec:
         {{ toYaml .Values.transformServices.sharedFileStore.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.transformServices.sharedFileStore.priorityClassName }}
+      priorityClassName: {{ .Values.transformServices.sharedFileStore.priorityClassName }}
+      {{- end }}
       containers:
         - name: shared-file-store-container
           image: {{ .Values.transformServices.sharedFileStore.image.registry }}/{{ .Values.transformServices.sharedFileStore.image.repository }}:{{ .Values.transformServices.sharedFileStore.image.tag }}

--- a/xenit-alfresco/templates/transform-services/shared-file-store/shared-file-store-pdb.yaml
+++ b/xenit-alfresco/templates/transform-services/shared-file-store/shared-file-store-pdb.yaml
@@ -1,0 +1,12 @@
+{{- if and (.Values.transformServices.enabled) (.Values.transformServices.sharedFileStore.enabled) (.Values.general.enterprise) (gt .Values.transformServices.sharedFileStore.replicas 1.0) -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: shared-file-store-pdb
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: shared-file-store
+{{- end }}

--- a/xenit-alfresco/templates/transform-services/transform-core-aio/transform-core-aio-deployment.yaml
+++ b/xenit-alfresco/templates/transform-services/transform-core-aio/transform-core-aio-deployment.yaml
@@ -35,6 +35,9 @@ spec:
         {{ toYaml .Values.transformServices.transformCoreAio.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.transformServices.transformCoreAio.priorityClassName }}
+      priorityClassName: {{ .Values.transformServices.transformCoreAio.priorityClassName }}
+      {{- end }}
       containers:
         - name: transform-core-aio-container
           image: {{ .Values.transformServices.transformCoreAio.image.registry }}/{{ .Values.transformServices.transformCoreAio.image.repository }}:{{ .Values.transformServices.transformCoreAio.image.tag }}

--- a/xenit-alfresco/templates/transform-services/transform-core-aio/transform-core-aio-pdb.yaml
+++ b/xenit-alfresco/templates/transform-services/transform-core-aio/transform-core-aio-pdb.yaml
@@ -1,0 +1,12 @@
+{{- if and (.Values.transformServices.enabled) (.Values.transformServices.transformCoreAio.enabled) (gt .Values.transformServices.transformCoreAio.replicas 1.0) -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: transform-core-aio-pdb
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: transform-core-aio
+{{- end }}

--- a/xenit-alfresco/templates/transform-services/transform-router/transform-router-deployment.yaml
+++ b/xenit-alfresco/templates/transform-services/transform-router/transform-router-deployment.yaml
@@ -35,6 +35,9 @@ spec:
         {{ toYaml .Values.transformServices.transformRouter.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.transformServices.transformRouter.priorityClassName }}
+      priorityClassName: {{ .Values.transformServices.transformRouter.priorityClassName }}
+      {{- end }}
       containers:
         - name: transform-router-container
           image: {{ .Values.transformServices.transformRouter.image.registry }}/{{ .Values.transformServices.transformRouter.image.repository }}:{{ .Values.transformServices.transformRouter.image.tag }}

--- a/xenit-alfresco/templates/transform-services/transform-router/transform-router-pdb.yaml
+++ b/xenit-alfresco/templates/transform-services/transform-router/transform-router-pdb.yaml
@@ -1,0 +1,12 @@
+{{- if and (.Values.transformServices.enabled) (.Values.transformServices.transformRouter.enabled) (.Values.general.enterprise) (gt .Values.transformServices.transformRouter.replicas 1.0) -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: transform-router-pdb
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: transform-router
+{{- end }}


### PR DESCRIPTION
This PR adds the option to specify priority class reference for any pods. It also adds pod disruption budgets for deployments / stateful sets that may run with more than one replica to ensure that pod pre-emption (due to priority class) and other constellations potentially triggering pod eviction at least attempt to keep service/availability uninterupted with one pod instance.